### PR TITLE
Feature: Leave Management Challenge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__
 .pytest_cache
 .mypy_cache
+.venv
 *.db
 *.pyc
 .env

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,204 @@
+# Design Document - Leave Management System
+
+**Author:** Hafiz Iskandar
+**Date:** 2026-06-01
+
+---
+
+## 1. API Design
+
+### Endpoints
+
+| Method | Path | Description | Success | Error |
+|--------|------|-------------|---------|-------|
+| GET | `/employees` | List all employees | 200 | - |
+| GET | `/employees/{id}` | Employee detail + balances | 200 | 404 |
+| POST | `/leave-requests` | Create a leave request | 201 | 422 |
+| GET | `/leave-requests` | List/filter leave requests | 200 | - |
+| GET | `/leave-requests/{id}` | Get a single request | 200 | 404 |
+| POST | `/leave-requests/{id}/review` | Approve or reject | 200 | 422 |
+| POST | `/leave-requests/{id}/cancel` | Cancel a request | 200 | 422 |
+| GET | `/leave-balances/{employee_id}` | Get leave balances | 200 | - |
+
+### Request/Response Shapes
+
+**POST `/leave-requests`**
+```json
+{
+  "employee_id": 2,
+  "leave_type": "annual",
+  "start_date": "2026-07-01",
+  "end_date": "2026-07-03",
+  "reason": "Holiday"
+}
+```
+Response: `LeaveRequestOut` (id, employee_id, leave_type, start_date, end_date, status, approved_by, approved_at)
+
+**POST `/leave-requests/{id}/review`**
+```json
+{
+  "approver_id": 1,
+  "decision": "approved"
+}
+```
+The `approver_id` field was added to fix the original hardcoded `approver_id=1` in the scaffold.
+In a real system this would come from the authenticated session instead.
+
+**GET `/leave-requests`** - all query params are optional:
+- `employee_id`, `status`, `leave_type`, `from_date`, `to_date`
+- `page` (default 1), `page_size` (default 20, max 100)
+
+Response: `{ items, total, page, page_size }` (offset-based pagination).
+
+---
+
+## 2. Data Model
+
+The scaffold provides three core tables:
+
+### `employees`
+- `id`, `name`, `email` (unique), `department`
+- `manager_id` → self-referential FK (nullable; top-level managers have no manager)
+- `joined_at`, `created_at`, `updated_at`
+
+### `leave_requests`
+- `id`, `employee_id` (FK), `leave_type` (enum), `start_date`, `end_date`, `reason`
+- `status` (enum: pending / approved / rejected / cancelled), default: pending
+- `approved_by` (FK → employees), `approved_at`
+
+### `leave_balances`
+- `id`, `employee_id` (FK), `leave_type` (enum), `year`
+- `total_days` (Float - supports half-days), `used_days` (Float)
+- `remaining_days` is a computed property: `total_days - used_days`
+
+**Key design notes:**
+- `Float` for days rather than integer to support half-day leaves without a schema change.
+- `leave_balances` is scoped per year - a new row per employee per leave type per year. This avoids year-boundary pollution.
+- No unique constraint on `(employee_id, leave_type, year)` in the scaffold; my implementation relies on the query being specific enough and does not add duplicates.
+
+---
+
+## 3. Edge Cases Identified
+
+### Overlapping leave requests
+Detected with a SQL range intersection query:
+`existing.start_date <= new.end_date AND existing.end_date >= new.start_date`
+Only non-cancelled and non-rejected requests are considered active.
+
+### Insufficient balance
+Checked at create time using `remaining_days` (total − used). Re-checked at approval time because the window between creation and approval could allow the balance to drop (e.g., another request is approved in between).
+If no balance row exists for that leave type/year, the request is treated as having `0` available days rather than auto-creating a zero-day balance row. This keeps failed validation side-effect free.
+
+### Self-approval
+`SelfApprovalError` raised if `approver_id == employee_id`. The approver must be the direct manager (`employee.manager_id == approver_id`).
+
+### Cancelling an approved leave restores balance
+`cancel_leave_request` checks if the leave was `APPROVED` before cancellation and reverses the `used_days` deduction. A `max(0, ...)` guard prevents underflow from any edge case.
+
+### UNPAID leave
+Never consumes a balance record. The check `leave_type != UNPAID` is applied both at create and approve time.
+
+### Concurrent approvals (two managers simultaneously)
+Handled with SQLAlchemy `with_for_update()` on the `LeaveBalance` row at approval time. This is a pessimistic lock - the second concurrent transaction will block until the first commits, then see the updated balance and raise `InsufficientBalanceError` if it's been exhausted.
+
+For the `LeaveRequest` row itself, the status check (`status == PENDING`) acts as an optimistic guard: only one transaction can flip the status from PENDING to APPROVED; the other will see the non-PENDING state and reject.
+
+### Back-dated leave
+`start_date < today` is rejected at create time.
+
+### Leave spanning year boundary
+Not handled in this implementation (see "What I Would Do With More Time"). Currently the balance bucket is keyed to `start_date.year`, so a request spanning Dec 31 → Jan 1 would deduct entirely from the starting year's balance.
+
+### Half-day leaves
+The data model (`Float` days) supports half-days. The current `_count_working_days` counts calendar days and would need a `0.5` multiplier if a `half_day: bool` field were added to `LeaveRequest`.
+
+### Idempotency of approval
+Attempting to approve an already-approved request raises `LeaveError("already approved")`. There is no silent no-op - this is intentional so callers know their request arrived late.
+
+---
+
+## 4. Tradeoffs and Decisions
+
+### SQLite for the demo
+**Chosen:** SQLite (as given in the scaffold).  
+**Alternative:** PostgreSQL.  
+**Why:** SQLite removes setup friction for the challenge evaluator. The code is compatible with PostgreSQL - just change `DATABASE_URL`. The one caveat is that `with_for_update()` on SQLite is a no-op (SQLite uses file-level locking), so the concurrency protection only kicks in properly with Postgres in production.
+
+### Synchronous FastAPI (not async)
+**Chosen:** Sync SQLAlchemy sessions.  
+**Alternative:** `asyncpg` + `SQLAlchemy async`.  
+**Why:** The scaffold uses sync SQLAlchemy. Async would require changing the session management, engine, and all ORM queries. For a CRUD-heavy leave system the throughput gains are modest. I kept it sync to avoid scope creep.
+
+### Pessimistic locking for balance deduction
+**Chosen:** `SELECT ... FOR UPDATE` on `LeaveBalance`.  
+**Alternative:** Optimistic locking (version column + retry on conflict).  
+**Why:** Leave approvals are low-frequency, so lock contention is rare. Pessimistic locking is simpler to reason about correctly: no retry logic, no partial commit risk. Optimistic locking would be preferable at high scale or with a distributed system.
+
+### Offset-based pagination
+**Chosen:** `OFFSET / LIMIT`.  
+**Alternative:** Cursor-based (keyset) pagination.  
+**Why:** The dataset size for a company's leave requests is small enough that offset pagination is fine. Cursor-based pagination is more stable for large, frequently-updated datasets (avoids the "page drift" problem), but adds implementation and API complexity not warranted here.
+
+### Balance deduction on approval, not on creation
+**Chosen:** Balance deducted when a leave is approved.  
+**Alternative:** Deduct on creation, refund on rejection.  
+**Why:** Creation represents intent; approval represents commitment. Deducting on creation would incorrectly block employees from requesting leave while a previous request is still pending (even if it will be rejected). The current approach means an employee could have multiple pending requests that together exceed their balance - the first to be approved wins. This is acceptable and noted.
+
+### approver_id in request body (not auth token)
+**Chosen:** Pass `approver_id` as a field in `LeaveRequestApprove`.  
+**Alternative:** Derive from authenticated session (JWT / session cookie).  
+**Why:** There is no auth system in the scaffold. Making the approver explicit in the body is the pragmatic choice for this challenge. In production, `approver_id` would come from the auth middleware.
+
+---
+
+## 5. What I Would Do With More Time
+
+**Authentication & authorization**
+Real JWT-based auth so that `approver_id` comes from the token, not the request body. Role-based access control (manager, HR admin, employee).
+
+**Weekend and public holiday exclusion**
+A `working_days(start, end)` function that skips weekends and a configurable public holiday calendar (stored in DB or from a Malaysian public holiday API). This would change the balance deduction from calendar days to working days.
+
+**Year-boundary leave handling**
+When a leave spans two calendar years, split the deduction across both years' balance records proportionally.
+
+**Async + PostgreSQL**
+Move to `asyncpg` + async SQLAlchemy for better throughput under real load. Use PostgreSQL for proper `SELECT FOR UPDATE` semantics.
+
+**Cursor-based pagination**
+Replace offset with a stable keyset cursor, especially for manager dashboards that list all pending requests across a large team.
+
+**Structured logging**
+Add request-scoped logging (employee_id, action, outcome) for audit trail purposes - essential for an HR system.
+
+**Half-day leaves**
+Add `is_half_day: bool` to `LeaveRequest`. Adjust `_count_working_days` to return `0.5` for same-day half-day requests.
+
+**Leave policy engine**
+Currently leave balances are seeded manually. A policy engine would define accrual rules (e.g., 1.17 days/month for annual leave) and automatically create/top-up balance records.
+
+**Delegation / acting manager**
+When a manager is on leave, a delegate should be able to approve. This requires a `delegate_manager_id` on `Employee` and updated authorization logic.
+
+---
+
+## 6. Running the Project
+
+```bash
+# Install dependencies
+make install
+
+# Run the server (seeds demo data on startup)
+make run
+
+# Run tests
+make test
+
+# Or directly from the virtualenv
+./.venv/bin/python -m pytest tests/ -v
+```
+
+Demo employees are seeded automatically:
+- **Alice Manager** (id=1) - no manager, can approve Bob and Carol's leaves
+- **Bob Engineer** (id=2) - manager: Alice, 14 annual + 12 sick days
+- **Carol Engineer** (id=3) - manager: Alice, 14 annual + 12 sick days

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,18 @@
 .PHONY: install run test lint clean
 
+PYTHON := .venv/bin/python
+PIP := .venv/bin/pip
+UVICORN := .venv/bin/uvicorn
+
 install:
-	pip install -r requirements.txt
+	python3 -m venv .venv
+	$(PIP) install -r requirements.txt
 
 run:
-	uvicorn src.app:app --reload --host 0.0.0.0 --port 8000
+	$(UVICORN) src.app:app --reload --host 0.0.0.0 --port 8000
 
 test:
-	python -m pytest tests/ -v
+	$(PYTHON) -m pytest tests/ -v
 
 clean:
 	rm -rf __pycache__ .pytest_cache *.db src/__pycache__ tests/__pycache__

--- a/src/app.py
+++ b/src/app.py
@@ -5,7 +5,7 @@ This is the entrypoint. Routes are defined but most business logic
 in services.py needs to be implemented to make everything work.
 """
 
-from datetime import date
+from datetime import date, datetime
 from typing import Optional
 
 from fastapi import FastAPI, Depends, HTTPException, Query
@@ -62,13 +62,14 @@ class LeaveRequestOut(BaseModel):
     reason: Optional[str]
     status: LeaveStatus
     approved_by: Optional[int]
-    approved_at: Optional[str]
+    approved_at: Optional[datetime]
 
     class Config:
         from_attributes = True
 
 
 class LeaveRequestApprove(BaseModel):
+    approver_id: int = Field(description="ID of the manager performing the review")
     decision: LeaveStatus = Field(description="approved or rejected")
 
 
@@ -150,7 +151,7 @@ def review_leave_request(
 ):
     try:
         lr = services.approve_leave_request(
-            db, leave_request_id=leave_request_id, approver_id=1, decision=body.decision,
+            db, leave_request_id=leave_request_id, approver_id=body.approver_id, decision=body.decision,
         )
         return lr
     except services.LeaveError as e:

--- a/src/models.py
+++ b/src/models.py
@@ -35,7 +35,7 @@ class Employee(Base):
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     manager = relationship("Employee", remote_side="Employee.id")
-    leave_requests = relationship("LeaveRequest", back_populates="employee")
+    leave_requests = relationship("LeaveRequest", back_populates="employee", foreign_keys="LeaveRequest.employee_id")
     leave_balances = relationship("LeaveBalance", back_populates="employee")
 
 

--- a/src/services.py
+++ b/src/services.py
@@ -34,6 +34,41 @@ class CannotModifyApprovedLeaveError(LeaveError):
     pass
 
 
+def _get_employee_or_404(db: Session, employee_id: int) -> Employee:
+    emp = db.query(Employee).filter(Employee.id == employee_id).first()
+    if not emp:
+        raise LeaveError(f"Employee {employee_id} not found")
+    return emp
+
+
+def _get_leave_request_or_404(db: Session, leave_request_id: int) -> LeaveRequest:
+    lr = db.query(LeaveRequest).filter(LeaveRequest.id == leave_request_id).first()
+    if not lr:
+        raise LeaveError(f"Leave request {leave_request_id} not found")
+    return lr
+
+
+def _count_working_days(start_date: date, end_date: date) -> float:
+    """Count calendar days inclusive. Weekend-skipping left as a future enhancement
+    (see DESIGN.md) - we use calendar days to keep the model simple and predictable."""
+    return float((end_date - start_date).days + 1)
+
+
+def _get_balance(
+    db: Session, employee_id: int, leave_type: LeaveType, year: int
+) -> LeaveBalance | None:
+    return (
+        db.query(LeaveBalance)
+        .filter(
+            LeaveBalance.employee_id == employee_id,
+            LeaveBalance.leave_type == leave_type,
+            LeaveBalance.year == year,
+        )
+        .with_for_update()  # pessimistic lock to prevent concurrent over-deduction
+        .first()
+    )
+
+
 def create_leave_request(
     db: Session,
     employee_id: int,
@@ -50,9 +85,59 @@ def create_leave_request(
     - start_date >= today (no back-dating)
     - No overlapping leave requests for the same employee
     - Employee has sufficient leave balance for the requested type
-    - end_date - start_date >= 0 (at least 1 day — or handle half-day logic)
+    - end_date - start_date >= 0 (at least 1 day - or handle half-day logic)
     """
-    raise NotImplementedError("Candidate must implement this")
+    _get_employee_or_404(db, employee_id)
+
+    today = date.today()
+    if start_date < today:
+        raise LeaveError("Leave start date cannot be in the past")
+    if end_date < start_date:
+        raise LeaveError("end_date must be on or after start_date")
+
+    # Overlap check: any active (non-cancelled, non-rejected) request whose
+    # date range intersects [start_date, end_date].
+    overlap = (
+        db.query(LeaveRequest)
+        .filter(
+            LeaveRequest.employee_id == employee_id,
+            LeaveRequest.status.not_in([LeaveStatus.CANCELLED, LeaveStatus.REJECTED]),
+            LeaveRequest.start_date <= end_date,
+            LeaveRequest.end_date >= start_date,
+        )
+        .first()
+    )
+    if overlap:
+        raise OverlappingLeaveError(
+            f"Leave overlaps with existing request {overlap.id} "
+            f"({overlap.start_date} – {overlap.end_date})"
+        )
+
+    days_requested = _count_working_days(start_date, end_date)
+
+    # UNPAID leave doesn't consume a balance bucket
+    if leave_type != LeaveType.UNPAID:
+        year = start_date.year
+        balance = _get_balance(db, employee_id, leave_type, year)
+        remaining_days = balance.remaining_days if balance else 0.0
+        if remaining_days < days_requested:
+            raise InsufficientBalanceError(
+                f"Insufficient balance: need {days_requested} day(s), "
+                f"have {remaining_days} remaining"
+            )
+
+    lr = LeaveRequest(
+        employee_id=employee_id,
+        leave_type=leave_type,
+        start_date=start_date,
+        end_date=end_date,
+        reason=reason,
+        status=LeaveStatus.PENDING,
+    )
+    db.add(lr)
+    db.commit()
+    db.refresh(lr)
+    return lr
 
 
 def approve_leave_request(
@@ -70,7 +155,43 @@ def approve_leave_request(
     - On approval: deduct from leave balance
     - On rejection: record reason in comment field if needed
     """
-    raise NotImplementedError("Candidate must implement this")
+    if decision not in (LeaveStatus.APPROVED, LeaveStatus.REJECTED):
+        raise LeaveError("Decision must be 'approved' or 'rejected'")
+
+    lr = _get_leave_request_or_404(db, leave_request_id)
+
+    if lr.status != LeaveStatus.PENDING:
+        raise LeaveError(f"Leave request is already {lr.status.value}, cannot review")
+
+    if lr.employee_id == approver_id:
+        raise SelfApprovalError("Employees cannot approve their own leave requests")
+
+    employee = _get_employee_or_404(db, lr.employee_id)
+    if employee.manager_id != approver_id:
+        raise LeaveError(
+            f"Approver {approver_id} is not the manager of employee {lr.employee_id}"
+        )
+
+    if decision == LeaveStatus.APPROVED:
+        if lr.leave_type != LeaveType.UNPAID:
+            year = lr.start_date.year
+            # with_for_update prevents two concurrent approvals double-deducting
+            balance = _get_balance(db, lr.employee_id, lr.leave_type, year)
+            days = _count_working_days(lr.start_date, lr.end_date)
+            remaining_days = balance.remaining_days if balance else 0.0
+            if remaining_days < days:
+                raise InsufficientBalanceError(
+                    f"Insufficient balance at approval time: need {days}, "
+                    f"have {remaining_days}"
+                )
+            balance.used_days += days
+
+    lr.status = decision
+    lr.approved_by = approver_id
+    lr.approved_at = datetime.utcnow()
+    db.commit()
+    db.refresh(lr)
+    return lr
 
 
 def cancel_leave_request(
@@ -84,7 +205,40 @@ def cancel_leave_request(
     - Can only cancel PENDING or APPROVED leaves
     - Cancelling an approved leave restores balance
     """
-    raise NotImplementedError("Candidate must implement this")
+    lr = _get_leave_request_or_404(db, leave_request_id)
+
+    if lr.employee_id != employee_id:
+        raise LeaveError("Only the leave owner can cancel this request")
+
+    if lr.status == LeaveStatus.CANCELLED:
+        raise LeaveError("Leave request is already cancelled")
+
+    if lr.status == LeaveStatus.REJECTED:
+        raise LeaveError("Rejected leave requests cannot be cancelled")
+
+    was_approved = lr.status == LeaveStatus.APPROVED
+
+    lr.status = LeaveStatus.CANCELLED
+
+    if was_approved and lr.leave_type != LeaveType.UNPAID:
+        year = lr.start_date.year
+        balance = (
+            db.query(LeaveBalance)
+            .filter(
+                LeaveBalance.employee_id == employee_id,
+                LeaveBalance.leave_type == lr.leave_type,
+                LeaveBalance.year == year,
+            )
+            .with_for_update()
+            .first()
+        )
+        if balance:
+            days = _count_working_days(lr.start_date, lr.end_date)
+            balance.used_days = max(0.0, balance.used_days - days)
+
+    db.commit()
+    db.refresh(lr)
+    return lr
 
 
 def get_leave_requests(
@@ -101,7 +255,27 @@ def get_leave_requests(
     List leave requests with filtering and pagination.
     Returns (items, total_count).
     """
-    raise NotImplementedError("Candidate must implement this")
+    q = db.query(LeaveRequest)
+
+    if employee_id is not None:
+        q = q.filter(LeaveRequest.employee_id == employee_id)
+    if status is not None:
+        q = q.filter(LeaveRequest.status == status)
+    if leave_type is not None:
+        q = q.filter(LeaveRequest.leave_type == leave_type)
+    if from_date is not None:
+        q = q.filter(LeaveRequest.end_date >= from_date)
+    if to_date is not None:
+        q = q.filter(LeaveRequest.start_date <= to_date)
+
+    total = q.count()
+    items = (
+        q.order_by(LeaveRequest.created_at.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+    return items, total
 
 
 def get_leave_balances(
@@ -112,7 +286,17 @@ def get_leave_balances(
     """
     Get leave balances for an employee for a given year (defaults to current year).
     """
-    raise NotImplementedError("Candidate must implement this")
+    if year is None:
+        year = date.today().year
+
+    return (
+        db.query(LeaveBalance)
+        .filter(
+            LeaveBalance.employee_id == employee_id,
+            LeaveBalance.year == year,
+        )
+        .all()
+    )
 
 
 def seed_demo_data(db: Session) -> None:

--- a/src/services.py
+++ b/src/services.py
@@ -87,7 +87,7 @@ def create_leave_request(
     - Employee has sufficient leave balance for the requested type
     - end_date - start_date >= 0 (at least 1 day - or handle half-day logic)
     """
-    _get_employee_or_404(db, employee_id)
+    employee = _get_employee_or_404(db, employee_id)  # 404 if employee doesn't exist
 
     today = date.today()
     if start_date < today:

--- a/src/services.py
+++ b/src/services.py
@@ -222,16 +222,7 @@ def cancel_leave_request(
 
     if was_approved and lr.leave_type != LeaveType.UNPAID:
         year = lr.start_date.year
-        balance = (
-            db.query(LeaveBalance)
-            .filter(
-                LeaveBalance.employee_id == employee_id,
-                LeaveBalance.leave_type == lr.leave_type,
-                LeaveBalance.year == year,
-            )
-            .with_for_update()
-            .first()
-        )
+        balance = _get_balance(db, employee_id, lr.leave_type, year)
         if balance:
             days = _count_working_days(lr.start_date, lr.end_date)
             balance.used_days = max(0.0, balance.used_days - days)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,44 +1,323 @@
 """
 Integration tests for the FastAPI leave management API.
-
-These tests use TestClient to exercise the full stack.
-They currently pass because they're placeholders — replace
-with real tests once you implement src/services.py.
 """
 
+import os
+import tempfile
 import unittest
+from datetime import date, timedelta
+
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
-from src.app import app
+TODAY = date.today()
+TOMORROW = TODAY + timedelta(days=1)
+IN_3_DAYS = TODAY + timedelta(days=3)
+IN_7_DAYS = TODAY + timedelta(days=7)
+IN_10_DAYS = TODAY + timedelta(days=10)
 
 
-class TestLeaveAPI(unittest.TestCase):
+def build_test_client():
+    """
+    Use a temp-file SQLite DB so that app.py's module-level create_all
+    and the dependency-override session all point to the same database.
+    We set DATABASE_URL via env before importing app to redirect the engine.
+    """
+    # Create a temp file for the test DB
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    db_url = f"sqlite:///{db_path}"
+
+    # Reload database module with our test URL
+    import importlib
+    import src.database as db_module
+    os.environ["DATABASE_URL"] = db_url
+    # Re-bind the engine to our temp DB
+    from sqlalchemy import create_engine as _ce
+    test_engine = _ce(db_url, connect_args={"check_same_thread": False})
+    db_module.engine = test_engine
+
+    from src.database import Base, get_db
+    Base.metadata.create_all(bind=test_engine)
+
+    from sqlalchemy.orm import sessionmaker
+    TestingSession = sessionmaker(autocommit=False, autoflush=False, bind=test_engine)
+
+    from src.services import seed_demo_data
+    from src.app import app
+
+    def override_get_db():
+        db = TestingSession()
+        try:
+            seed_demo_data(db)
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app, raise_server_exceptions=True)
+    return client, db_path
+
+
+class TestEmployeeRoutes(unittest.TestCase):
 
     def setUp(self):
-        self.client = TestClient(app)
+        from src.app import app as _app
+        self.app = _app
+        self.client, self.db_path = build_test_client()
+
+    def tearDown(self):
+        self.app.dependency_overrides.clear()
+        try:
+            os.unlink(self.db_path)
+        except OSError:
+            pass
 
     def test_list_employees(self):
         resp = self.client.get("/employees")
         self.assertEqual(resp.status_code, 200)
-        self.assertIsInstance(resp.json(), list)
+        data = resp.json()
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 3)
+        names = {e["name"] for e in data}
+        self.assertIn("Alice Manager", names)
 
-    def test_get_employee(self):
-        resp = self.client.get("/employees/1")
-        # May return 200 or 404 depending on seed data
-        self.assertIn(resp.status_code, (200, 404))
+    def test_get_employee_found(self):
+        employees = self.client.get("/employees").json()
+        bob = next(e for e in employees if e["name"] == "Bob Engineer")
+        resp = self.client.get(f"/employees/{bob['id']}")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("employee", data)
+        self.assertIn("leave_balances", data)
+        self.assertEqual(data["employee"]["name"], "Bob Engineer")
 
-    def test_create_leave_request(self):
-        resp = self.client.post("/leave-requests", json={
-            "employee_id": 2,
-            "leave_type": "annual",
-            "start_date": str(date.today() + timedelta(days=7)),
-            "end_date": str(date.today() + timedelta(days=9)),
+    def test_get_employee_not_found(self):
+        resp = self.client.get("/employees/9999")
+        self.assertEqual(resp.status_code, 404)
+
+
+class TestLeaveRequestRoutes(unittest.TestCase):
+
+    def setUp(self):
+        from src.app import app as _app
+        self.app = _app
+        self.client, self.db_path = build_test_client()
+        employees = self.client.get("/employees").json()
+        self.alice = next(e for e in employees if e["name"] == "Alice Manager")
+        self.bob = next(e for e in employees if e["name"] == "Bob Engineer")
+        self.carol = next(e for e in employees if e["name"] == "Carol Engineer")
+
+    def tearDown(self):
+        self.app.dependency_overrides.clear()
+        try:
+            os.unlink(self.db_path)
+        except OSError:
+            pass
+
+    def _create_leave(self, employee_id, start=None, end=None, leave_type="annual"):
+        return self.client.post("/leave-requests", json={
+            "employee_id": employee_id,
+            "leave_type": leave_type,
+            "start_date": str(start or TOMORROW),
+            "end_date": str(end or IN_3_DAYS),
         })
-        # Without service implementation, expect 422 or 500
-        self.assertIn(resp.status_code, (201, 422, 500))
+
+    def test_create_leave_request_success(self):
+        resp = self._create_leave(self.bob["id"])
+        self.assertEqual(resp.status_code, 201)
+        data = resp.json()
+        self.assertEqual(data["status"], "pending")
+        self.assertEqual(data["employee_id"], self.bob["id"])
+        self.assertEqual(data["leave_type"], "annual")
+
+    def test_create_leave_request_insufficient_balance(self):
+        resp = self._create_leave(self.bob["id"], end=TODAY + timedelta(days=30))
+        self.assertEqual(resp.status_code, 422)
+        self.assertIn("Insufficient", resp.json()["detail"])
+
+    def test_create_leave_request_backdated(self):
+        resp = self._create_leave(self.bob["id"], start=TODAY - timedelta(days=1))
+        self.assertEqual(resp.status_code, 422)
+
+    def test_create_leave_request_overlap(self):
+        self._create_leave(self.bob["id"], start=TOMORROW, end=IN_7_DAYS)
+        resp = self._create_leave(self.bob["id"], start=IN_3_DAYS, end=IN_10_DAYS)
+        self.assertEqual(resp.status_code, 422)
+        self.assertIn("overlap", resp.json()["detail"].lower())
+
+    def test_list_leave_requests(self):
+        self._create_leave(self.bob["id"])
+        resp = self.client.get("/leave-requests")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("items", data)
+        self.assertIn("total", data)
+        self.assertGreaterEqual(data["total"], 1)
+
+    def test_list_leave_requests_filter_by_employee(self):
+        self._create_leave(self.bob["id"])
+        self._create_leave(self.carol["id"], start=IN_7_DAYS, end=IN_10_DAYS)
+        resp = self.client.get(f"/leave-requests?employee_id={self.bob['id']}")
+        self.assertEqual(resp.status_code, 200)
+        items = resp.json()["items"]
+        self.assertTrue(all(i["employee_id"] == self.bob["id"] for i in items))
+
+    def test_list_leave_requests_filter_by_status(self):
+        self._create_leave(self.bob["id"])
+        resp = self.client.get("/leave-requests?status=pending")
+        self.assertEqual(resp.status_code, 200)
+        items = resp.json()["items"]
+        self.assertTrue(all(i["status"] == "pending" for i in items))
+
+    def test_list_leave_requests_pagination(self):
+        self._create_leave(self.bob["id"], start=TOMORROW, end=TOMORROW + timedelta(days=1))
+        self._create_leave(self.bob["id"], start=IN_7_DAYS, end=IN_7_DAYS + timedelta(days=1))
+        resp = self.client.get(f"/leave-requests?employee_id={self.bob['id']}&page=1&page_size=1")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(len(data["items"]), 1)
+        self.assertEqual(data["total"], 2)
+
+    def test_get_leave_request_by_id(self):
+        created = self._create_leave(self.bob["id"]).json()
+        resp = self.client.get(f"/leave-requests/{created['id']}")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["id"], created["id"])
+
+    def test_get_leave_request_not_found(self):
+        resp = self.client.get("/leave-requests/9999")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_review_approve_leave_request(self):
+        lr = self._create_leave(self.bob["id"]).json()
+        resp = self.client.post(f"/leave-requests/{lr['id']}/review", json={
+            "approver_id": self.alice["id"],
+            "decision": "approved",
+        })
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["status"], "approved")
+        self.assertEqual(resp.json()["approved_by"], self.alice["id"])
+
+    def test_review_reject_leave_request(self):
+        lr = self._create_leave(self.bob["id"]).json()
+        resp = self.client.post(f"/leave-requests/{lr['id']}/review", json={
+            "approver_id": self.alice["id"],
+            "decision": "rejected",
+        })
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["status"], "rejected")
+
+    def test_review_self_approval_rejected(self):
+        lr = self._create_leave(self.bob["id"]).json()
+        resp = self.client.post(f"/leave-requests/{lr['id']}/review", json={
+            "approver_id": self.bob["id"],
+            "decision": "approved",
+        })
+        self.assertEqual(resp.status_code, 422)
+        self.assertIn("own", resp.json()["detail"].lower())
+
+    def test_review_non_manager_rejected(self):
+        lr = self._create_leave(self.bob["id"]).json()
+        resp = self.client.post(f"/leave-requests/{lr['id']}/review", json={
+            "approver_id": self.carol["id"],
+            "decision": "approved",
+        })
+        self.assertEqual(resp.status_code, 422)
+
+    def test_cancel_pending_leave(self):
+        lr = self._create_leave(self.bob["id"]).json()
+        resp = self.client.post(
+            f"/leave-requests/{lr['id']}/cancel",
+            params={"employee_id": self.bob["id"]},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["status"], "cancelled")
+
+    def test_cancel_approved_leave(self):
+        lr = self._create_leave(self.bob["id"]).json()
+        self.client.post(f"/leave-requests/{lr['id']}/review", json={
+            "approver_id": self.alice["id"],
+            "decision": "approved",
+        })
+        resp = self.client.post(
+            f"/leave-requests/{lr['id']}/cancel",
+            params={"employee_id": self.bob["id"]},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["status"], "cancelled")
+
+    def test_cancel_by_non_owner_rejected(self):
+        lr = self._create_leave(self.bob["id"]).json()
+        resp = self.client.post(
+            f"/leave-requests/{lr['id']}/cancel",
+            params={"employee_id": self.carol["id"]},
+        )
+        self.assertEqual(resp.status_code, 422)
+
+    def test_cancel_already_cancelled_rejected(self):
+        lr = self._create_leave(self.bob["id"]).json()
+        self.client.post(f"/leave-requests/{lr['id']}/cancel", params={"employee_id": self.bob["id"]})
+        resp = self.client.post(f"/leave-requests/{lr['id']}/cancel", params={"employee_id": self.bob["id"]})
+        self.assertEqual(resp.status_code, 422)
 
 
-from datetime import date, timedelta
+class TestLeaveBalanceRoutes(unittest.TestCase):
+
+    def setUp(self):
+        from src.app import app as _app
+        self.app = _app
+        self.client, self.db_path = build_test_client()
+        employees = self.client.get("/employees").json()
+        self.bob = next(e for e in employees if e["name"] == "Bob Engineer")
+        self.alice = next(e for e in employees if e["name"] == "Alice Manager")
+
+    def tearDown(self):
+        self.app.dependency_overrides.clear()
+        try:
+            os.unlink(self.db_path)
+        except OSError:
+            pass
+
+    def test_get_balances(self):
+        resp = self.client.get(f"/leave-balances/{self.bob['id']}")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 2)
+        types = {b["leave_type"] for b in data}
+        self.assertIn("annual", types)
+        self.assertIn("sick", types)
+
+    def test_get_balances_with_year(self):
+        resp = self.client.get(f"/leave-balances/{self.bob['id']}?year={TODAY.year}")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertGreater(len(data), 0)
+        for b in data:
+            self.assertEqual(b["year"], TODAY.year)
+
+    def test_get_balances_approval_reduces_remaining(self):
+        # Create and approve a leave
+        lr_resp = self.client.post("/leave-requests", json={
+            "employee_id": self.bob["id"],
+            "leave_type": "annual",
+            "start_date": str(TOMORROW),
+            "end_date": str(IN_3_DAYS),
+        })
+        lr = lr_resp.json()
+        self.client.post(f"/leave-requests/{lr['id']}/review", json={
+            "approver_id": self.alice["id"],
+            "decision": "approved",
+        })
+
+        resp = self.client.get(f"/leave-balances/{self.bob['id']}")
+        annual = next(b for b in resp.json() if b["leave_type"] == "annual")
+        days_taken = (IN_3_DAYS - TOMORROW).days + 1
+        self.assertEqual(annual["used_days"], float(days_taken))
+        self.assertEqual(annual["remaining_days"], 14.0 - days_taken)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,15 +1,5 @@
 """
 Tests for the leave management service layer.
-
-These tests are currently empty and use placeholder asserts.
-When you implement src/services.py, write real tests here.
-
-Consider:
-- What happens when you try to create overlapping leave?
-- What happens when balance is insufficient?
-- Can an employee approve their own leave?
-- Can you cancel an already-cancelled leave?
-- Does cancelling an approved leave restore the balance?
 """
 
 import unittest
@@ -19,7 +9,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from src.database import Base
-from src.models import LeaveType, LeaveStatus
+from src.models import Employee, LeaveBalance, LeaveType, LeaveStatus
 from src.services import (
     seed_demo_data,
     create_leave_request,
@@ -30,23 +20,28 @@ from src.services import (
     InsufficientBalanceError,
     OverlappingLeaveError,
     SelfApprovalError,
+    LeaveError,
 )
+
+TODAY = date.today()
+TOMORROW = TODAY + timedelta(days=1)
+IN_3_DAYS = TODAY + timedelta(days=3)
+IN_7_DAYS = TODAY + timedelta(days=7)
+IN_10_DAYS = TODAY + timedelta(days=10)
+IN_14_DAYS = TODAY + timedelta(days=14)
+YESTERDAY = TODAY - timedelta(days=1)
 
 
 class TestLeaveServices(unittest.TestCase):
-    """You must implement and expand these tests."""
-
-    @classmethod
-    def setUpClass(cls):
-        engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
-        Base.metadata.create_all(bind=engine)
-        cls.Session = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
     def setUp(self):
-        self.db = self.Session()
+        # Fresh in-memory DB per test for full isolation
+        from sqlalchemy import create_engine
+        engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+        Base.metadata.create_all(bind=engine)
+        Session = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+        self.db = Session()
         seed_demo_data(self.db)
-        # Fetch demo employees
-        from src.models import Employee
         self.alice = self.db.query(Employee).filter(Employee.email == "alice@company.com").first()
         self.bob = self.db.query(Employee).filter(Employee.email == "bob@company.com").first()
         self.carol = self.db.query(Employee).filter(Employee.email == "carol@company.com").first()
@@ -54,37 +49,279 @@ class TestLeaveServices(unittest.TestCase):
     def tearDown(self):
         self.db.close()
 
-    def test_create_leave_request(self):
-        # TODO: implement
-        self.assertTrue(True)
+    # ── create_leave_request ─────────────────────────────────────────────
+
+    def test_create_leave_request_happy_path(self):
+        lr = create_leave_request(
+            self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS
+        )
+        self.assertEqual(lr.employee_id, self.bob.id)
+        self.assertEqual(lr.leave_type, LeaveType.ANNUAL)
+        self.assertEqual(lr.status, LeaveStatus.PENDING)
+        self.assertEqual(lr.start_date, TOMORROW)
+        self.assertEqual(lr.end_date, IN_3_DAYS)
+
+    def test_create_leave_request_does_not_deduct_balance_on_create(self):
+        """Balance deduction happens on approval, not on create."""
+        balances_before = get_leave_balances(self.db, self.bob.id)
+        annual_before = next(b for b in balances_before if b.leave_type == LeaveType.ANNUAL)
+        used_before = annual_before.used_days
+
+        create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+
+        balances_after = get_leave_balances(self.db, self.bob.id)
+        annual_after = next(b for b in balances_after if b.leave_type == LeaveType.ANNUAL)
+        self.assertEqual(annual_after.used_days, used_before)
+
+    def test_create_leave_request_single_day(self):
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.SICK, TOMORROW, TOMORROW)
+        self.assertEqual(lr.start_date, lr.end_date)
 
     def test_create_leave_request_insufficient_balance(self):
-        # TODO: implement
-        self.assertTrue(True)
+        # Bob has 14 annual days; request 20 days
+        with self.assertRaises(InsufficientBalanceError):
+            create_leave_request(
+                self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, TODAY + timedelta(days=21)
+            )
 
     def test_create_leave_request_overlapping_dates(self):
-        # TODO: implement
-        self.assertTrue(True)
+        create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, IN_7_DAYS, IN_10_DAYS)
+        with self.assertRaises(OverlappingLeaveError):
+            create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, IN_7_DAYS + timedelta(days=1), IN_14_DAYS)
+
+    def test_create_leave_request_overlap_adjacent_is_allowed(self):
+        """A request ending on day N and another starting on day N+1 should not overlap."""
+        create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, IN_7_DAYS, IN_10_DAYS)
+        lr2 = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, IN_10_DAYS + timedelta(days=1), IN_14_DAYS)
+        self.assertIsNotNone(lr2.id)
+
+    def test_create_leave_request_backdated_rejected(self):
+        with self.assertRaises(LeaveError):
+            create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, YESTERDAY, TOMORROW)
+
+    def test_create_leave_request_end_before_start_rejected(self):
+        with self.assertRaises(LeaveError):
+            create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, IN_7_DAYS, IN_3_DAYS)
+
+    def test_create_leave_request_unknown_employee(self):
+        with self.assertRaises(LeaveError):
+            create_leave_request(self.db, 9999, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+
+    def test_create_leave_request_unpaid_no_balance_needed(self):
+        """UNPAID leave should succeed even without a balance record."""
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.UNPAID, TOMORROW, IN_7_DAYS)
+        self.assertEqual(lr.leave_type, LeaveType.UNPAID)
+        self.assertEqual(lr.status, LeaveStatus.PENDING)
+
+    def test_failed_create_does_not_create_zero_balance_row(self):
+        balances_before = get_leave_balances(self.db, self.bob.id)
+        self.assertFalse(any(b.leave_type == LeaveType.PERSONAL for b in balances_before))
+
+        with self.assertRaises(InsufficientBalanceError):
+            create_leave_request(
+                self.db, self.bob.id, LeaveType.PERSONAL, TOMORROW, TOMORROW
+            )
+
+        balances_after = get_leave_balances(self.db, self.bob.id)
+        self.assertFalse(any(b.leave_type == LeaveType.PERSONAL for b in balances_after))
+
+    def test_cancelled_request_does_not_block_overlap(self):
+        """A cancelled leave in the same date range should not trigger OverlappingLeaveError."""
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, IN_7_DAYS, IN_10_DAYS)
+        cancel_leave_request(self.db, lr.id, self.bob.id)
+        lr2 = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, IN_7_DAYS, IN_10_DAYS)
+        self.assertEqual(lr2.status, LeaveStatus.PENDING)
+
+    # ── approve_leave_request ────────────────────────────────────────────
 
     def test_approve_leave_request(self):
-        # TODO: implement
-        self.assertTrue(True)
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        approved = approve_leave_request(self.db, lr.id, self.alice.id, LeaveStatus.APPROVED)
+        self.assertEqual(approved.status, LeaveStatus.APPROVED)
+        self.assertEqual(approved.approved_by, self.alice.id)
+        self.assertIsNotNone(approved.approved_at)
+
+    def test_approve_deducts_balance(self):
+        days = (IN_3_DAYS - TOMORROW).days + 1  # 3 days
+        balances = get_leave_balances(self.db, self.bob.id)
+        annual = next(b for b in balances if b.leave_type == LeaveType.ANNUAL)
+        used_before = annual.used_days
+
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        approve_leave_request(self.db, lr.id, self.alice.id, LeaveStatus.APPROVED)
+
+        self.db.expire(annual)
+        self.assertEqual(annual.used_days, used_before + days)
+
+    def test_reject_leave_request(self):
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        rejected = approve_leave_request(self.db, lr.id, self.alice.id, LeaveStatus.REJECTED)
+        self.assertEqual(rejected.status, LeaveStatus.REJECTED)
+
+    def test_reject_does_not_deduct_balance(self):
+        balances = get_leave_balances(self.db, self.bob.id)
+        annual = next(b for b in balances if b.leave_type == LeaveType.ANNUAL)
+        used_before = annual.used_days
+
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        approve_leave_request(self.db, lr.id, self.alice.id, LeaveStatus.REJECTED)
+
+        self.db.expire(annual)
+        self.assertEqual(annual.used_days, used_before)
 
     def test_self_approval_rejected(self):
-        # TODO: implement
-        self.assertTrue(True)
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        with self.assertRaises(SelfApprovalError):
+            approve_leave_request(self.db, lr.id, self.bob.id, LeaveStatus.APPROVED)
+
+    def test_non_manager_cannot_approve(self):
+        """Carol is not Bob's manager, so she cannot approve Bob's leave."""
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        with self.assertRaises(LeaveError):
+            approve_leave_request(self.db, lr.id, self.carol.id, LeaveStatus.APPROVED)
+
+    def test_cannot_approve_already_approved(self):
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        approve_leave_request(self.db, lr.id, self.alice.id, LeaveStatus.APPROVED)
+        with self.assertRaises(LeaveError):
+            approve_leave_request(self.db, lr.id, self.alice.id, LeaveStatus.APPROVED)
+
+    def test_cannot_approve_cancelled(self):
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        cancel_leave_request(self.db, lr.id, self.bob.id)
+        with self.assertRaises(LeaveError):
+            approve_leave_request(self.db, lr.id, self.alice.id, LeaveStatus.APPROVED)
+
+    def test_approve_nonexistent_request(self):
+        with self.assertRaises(LeaveError):
+            approve_leave_request(self.db, 9999, self.alice.id, LeaveStatus.APPROVED)
+
+    def test_invalid_decision_rejected(self):
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        with self.assertRaises(LeaveError):
+            approve_leave_request(self.db, lr.id, self.alice.id, LeaveStatus.PENDING)
+
+    # ── cancel_leave_request ─────────────────────────────────────────────
+
+    def test_cancel_pending_leave(self):
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        cancelled = cancel_leave_request(self.db, lr.id, self.bob.id)
+        self.assertEqual(cancelled.status, LeaveStatus.CANCELLED)
 
     def test_cancel_approved_leave_restores_balance(self):
-        # TODO: implement
-        self.assertTrue(True)
+        days = (IN_3_DAYS - TOMORROW).days + 1
+        balances = get_leave_balances(self.db, self.bob.id)
+        annual = next(b for b in balances if b.leave_type == LeaveType.ANNUAL)
+        used_before = annual.used_days
+
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        approve_leave_request(self.db, lr.id, self.alice.id, LeaveStatus.APPROVED)
+        cancel_leave_request(self.db, lr.id, self.bob.id)
+
+        self.db.expire(annual)
+        self.assertEqual(annual.used_days, used_before)
+
+    def test_cancel_by_non_owner_rejected(self):
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        with self.assertRaises(LeaveError):
+            cancel_leave_request(self.db, lr.id, self.carol.id)
+
+    def test_cancel_already_cancelled_rejected(self):
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        cancel_leave_request(self.db, lr.id, self.bob.id)
+        with self.assertRaises(LeaveError):
+            cancel_leave_request(self.db, lr.id, self.bob.id)
+
+    def test_cancel_rejected_leave_not_allowed(self):
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        approve_leave_request(self.db, lr.id, self.alice.id, LeaveStatus.REJECTED)
+        with self.assertRaises(LeaveError):
+            cancel_leave_request(self.db, lr.id, self.bob.id)
+
+    # ── get_leave_requests ───────────────────────────────────────────────
 
     def test_list_leave_requests_with_filters(self):
-        # TODO: implement
-        self.assertTrue(True)
+        create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        create_leave_request(self.db, self.carol.id, LeaveType.SICK, IN_7_DAYS, IN_10_DAYS)
+
+        items, total = get_leave_requests(self.db, employee_id=self.bob.id)
+        self.assertTrue(all(lr.employee_id == self.bob.id for lr in items))
+
+        items, total = get_leave_requests(self.db, leave_type=LeaveType.SICK)
+        self.assertTrue(all(lr.leave_type == LeaveType.SICK for lr in items))
+
+    def test_list_leave_requests_pagination(self):
+        for i in range(5):
+            start = TODAY + timedelta(days=1 + i * 3)
+            end = start + timedelta(days=1)
+            create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, start, end)
+
+        page1, total = get_leave_requests(self.db, employee_id=self.bob.id, page=1, page_size=2)
+        page2, _ = get_leave_requests(self.db, employee_id=self.bob.id, page=2, page_size=2)
+
+        self.assertEqual(len(page1), 2)
+        self.assertEqual(len(page2), 2)
+        self.assertEqual(total, 5)
+        ids_p1 = {lr.id for lr in page1}
+        ids_p2 = {lr.id for lr in page2}
+        self.assertTrue(ids_p1.isdisjoint(ids_p2))
+
+    def test_list_leave_requests_status_filter(self):
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        approve_leave_request(self.db, lr.id, self.alice.id, LeaveStatus.APPROVED)
+        create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, IN_7_DAYS, IN_10_DAYS)
+
+        approved_items, _ = get_leave_requests(self.db, status=LeaveStatus.APPROVED)
+        self.assertTrue(all(lr.status == LeaveStatus.APPROVED for lr in approved_items))
+
+        pending_items, _ = get_leave_requests(self.db, status=LeaveStatus.PENDING)
+        self.assertTrue(all(lr.status == LeaveStatus.PENDING for lr in pending_items))
+
+    def test_list_leave_requests_date_range_filter(self):
+        create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, IN_7_DAYS, IN_10_DAYS)
+
+        items, total = get_leave_requests(self.db, from_date=IN_7_DAYS)
+        self.assertEqual(total, 1)
+        self.assertEqual(items[0].start_date, IN_7_DAYS)
+
+    def test_list_all_returns_all_employees(self):
+        create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        create_leave_request(self.db, self.carol.id, LeaveType.SICK, IN_7_DAYS, IN_10_DAYS)
+
+        _, total = get_leave_requests(self.db)
+        self.assertEqual(total, 2)
+
+    # ── get_leave_balances ───────────────────────────────────────────────
 
     def test_get_leave_balances(self):
-        # TODO: implement
-        self.assertTrue(True)
+        balances = get_leave_balances(self.db, self.bob.id)
+        self.assertEqual(len(balances), 2)
+        types = {b.leave_type for b in balances}
+        self.assertIn(LeaveType.ANNUAL, types)
+        self.assertIn(LeaveType.SICK, types)
+
+    def test_get_leave_balances_defaults_to_current_year(self):
+        balances = get_leave_balances(self.db, self.bob.id)
+        for b in balances:
+            self.assertEqual(b.year, date.today().year)
+
+    def test_get_leave_balances_explicit_year(self):
+        balances = get_leave_balances(self.db, self.bob.id, year=date.today().year)
+        self.assertGreater(len(balances), 0)
+
+    def test_get_leave_balances_unknown_year_returns_empty(self):
+        balances = get_leave_balances(self.db, self.bob.id, year=1900)
+        self.assertEqual(balances, [])
+
+    def test_remaining_days_computed_correctly(self):
+        lr = create_leave_request(self.db, self.bob.id, LeaveType.ANNUAL, TOMORROW, IN_3_DAYS)
+        approve_leave_request(self.db, lr.id, self.alice.id, LeaveStatus.APPROVED)
+
+        balances = get_leave_balances(self.db, self.bob.id)
+        annual = next(b for b in balances if b.leave_type == LeaveType.ANNUAL)
+        days_taken = (IN_3_DAYS - TOMORROW).days + 1
+        self.assertEqual(annual.remaining_days, 14.0 - days_taken)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Built the leave management API service layer for the FastAPI scaffold, including leave creation, approval/rejection, cancellation, filtered listing with pagination, and leave balance retrieval.

The implementation covers the required business rules such as:
- date validation
- overlapping leave prevention
- insufficient balance checks
- manager-only approval
- self-approval prevention
- balance deduction on approval and restoration on cancellation

I also added comprehensive unit and integration tests for the core workflows and edge cases.

## Design Document

Attached in this PR as `DESIGN.md`.

Key points covered in the design doc:
- API design decisions
- data model considerations
- edge cases and tradeoffs
- concurrency considerations
- what I would improve with more time

## Implementation Notes

A few implementation decisions worth calling out:

- Leave balance is deducted on approval rather than at request creation. This keeps pending requests from prematurely consuming quota.
- Balance is re-checked at approval time to handle the gap between request creation and manager review.
- Overlap detection uses an inclusive date-range intersection check.
- Unpaid leave does not consume balance.
- If no balance row exists for a leave type/year, the request is treated as having zero available days rather than creating a zero-day balance record during failed validation.
- I used offset-based pagination for simplicity and readability in this challenge.
- Concurrency is discussed in `DESIGN.md`; the implementation uses `with_for_update()` on balance reads, with the caveat that SQLite has limited locking semantics compared to PostgreSQL.
- For local verification, I aligned the project workflow to the repo virtualenv and validated the app using `make test` and `make run`, which wrap the project pytest and uvicorn commands.

## Checklist

- [x] I have written and attached a DESIGN.md
- [x] I have implemented the required service functions in src/services.py
- [x] Tests pass (`make test`, which runs the project venv pytest command)
- [x] Server starts and responds to requests (`make run`, which starts `uvicorn src.app:app --reload`)
- [x] I have considered edge cases (overlapping leave, insufficient balance, self-approval)

## About You

I’m a full stack developer with 5+ years of experience building web applications, backend APIs, system integrations, and workflow-driven platforms. My work has covered HR-related systems, government and regulatory platforms, and internal business tools, which is part of why this challenge felt genuinely relevant to me.

I’m most comfortable working with Node.js, Laravel/PHP, React, MySQL, PostgreSQL, REST APIs, and Git. I’ve also worked with workflow automation using n8n and on systems where secure, reliable integration between services is important.

What I look for in a workplace is a team that values practical engineering, clear communication, and thoughtful product decisions. I enjoy collaborating on backend architecture, building reliable APIs, and working on systems that solve real operational problems for users.

- LinkedIn: [Hafiz Iskandar](https://www.linkedin.com/in/hafiziskandar/)  
- Website: [mhafiziskandar.dev](https://mhafiziskandar.dev/)  
- Email: mhafiziskandar.dev@gmail.com