### PR TITLE
PR submission Kakitangan back end challenge by koyomdev21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 *.db
 *.pyc
 .env
+CONTEXT.md

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,363 @@
+# Design Document - Leave Management System
+
+**Author:** koyomdev21
+**Date:** 2026-06-03
+
+## 1. API Design
+
+### Create Leave Request
+
+```http
+POST /leave-requests
+```
+
+Request body:
+
+```json
+{
+  "employee_id": 2,
+  "leave_type": "annual",
+  "start_date": "2026-06-10",
+  "start_session": "pm",
+  "end_date": "2026-06-12",
+  "end_session": "pm",
+  "reason": "Family commitment"
+}
+```
+
+`start_session` and `end_session` are optional. When omitted, the request defaults to a full-day period by using `start_session = "am"` and `end_session = "pm"`.
+
+Response body:
+
+```json
+{
+  "id": 10,
+  "employee_id": 2,
+  "leave_type": "annual",
+  "start_date": "2026-06-10",
+  "start_session": "pm",
+  "end_date": "2026-06-12",
+  "end_session": "pm",
+  "leave_usage_days": 2.5,
+  "reason": "Family commitment",
+  "status": "pending",
+  "approved_by": null,
+  "approved_at": null
+}
+```
+
+Expected status codes:
+
+- `201 Created` when the leave request is accepted.
+- `422 Unprocessable Entity` for invalid date/session ranges, overlapping leave, missing balance, or insufficient available leave.
+- `404 Not Found` if the employee does not exist.
+
+### Preview Leave Usage
+
+```http
+POST /leave-requests/preview
+```
+
+Request body uses the same date and session fields as `POST /leave-requests`.
+
+Response body:
+
+```json
+{
+  "leave_usage_days": 2.5,
+  "leave_usage_by_year": {
+    "2026": 2.5
+  },
+  "working_sessions": [
+    { "date": "2026-06-10", "sessions": ["pm"], "days": 0.5 },
+    { "date": "2026-06-11", "sessions": ["am", "pm"], "days": 1.0 },
+    { "date": "2026-06-12", "sessions": ["am", "pm"], "days": 1.0 }
+  ],
+  "excluded_dates": [
+    { "date": "2026-06-13", "reason": "weekend" },
+    { "date": "2026-08-31", "reason": "public_holiday", "name": "National Day" }
+  ]
+}
+```
+
+The preview endpoint does not create a leave request, reserve leave, or mutate balances. It exists so the frontend can show employees exactly how much leave their selected period would consume.
+
+### Review Leave Request
+
+```http
+POST /leave-requests/{leave_request_id}/review
+```
+
+Request body:
+
+```json
+{
+  "decision": "approved"
+}
+```
+
+Only `approved` and `rejected` are valid review decisions.
+
+Expected status codes:
+
+- `200 OK` when the pending request is approved or rejected.
+- `200 OK` when retrying the same final decision for an already approved or rejected request.
+- `422 Unprocessable Entity` for invalid transitions, self-approval, non-manager approval, insufficient balance, or changed leave usage.
+- `404 Not Found` if the leave request or approver does not exist.
+
+### Cancel Leave Request
+
+```http
+POST /leave-requests/{leave_request_id}/cancel?employee_id=2
+```
+
+Only the leave request owner can cancel. Pending leave can be cancelled without balance changes. Approved leave can be cancelled only before the leave start date, and cancellation restores the deducted balance.
+
+Expected status codes:
+
+- `200 OK` when cancellation succeeds.
+- `422 Unprocessable Entity` when the employee is not the owner, the request is already rejected/cancelled, or the approved leave has started.
+- `404 Not Found` if the leave request does not exist.
+
+### List Leave Requests
+
+```http
+GET /leave-requests
+```
+
+Supported filters:
+
+- `employee_id`
+- `status`
+- `leave_type`
+- `from_date`
+- `to_date`
+- `page`
+- `page_size`
+
+The listing response includes `leave_usage_days` so clients do not need to recalculate leave usage for every row.
+
+### Get Leave Balances
+
+```http
+GET /leave-balances/{employee_id}?year=2026
+```
+
+Balances are exposed in days:
+
+```json
+[
+  {
+    "leave_type": "annual",
+    "year": 2026,
+    "total_days": 14.0,
+    "used_days": 3.5,
+    "remaining_days": 10.5
+  }
+]
+```
+
+## 2. Data Model
+
+### employees
+
+Existing employee table:
+
+- `id`
+- `name`
+- `email`
+- `department`
+- `manager_id`
+- timestamps
+
+`manager_id` identifies the direct manager who can review the employee's leave requests.
+
+### leave_requests
+
+Leave requests should store the selected period and the calculated usage:
+
+- `id`
+- `employee_id`
+- `leave_type`
+- `start_date`
+- `start_session`
+- `end_date`
+- `end_session`
+- `leave_usage_days`
+- `reason`
+- `status`
+- `approved_by`
+- `approved_at`
+- timestamps
+
+`start_session` and `end_session` are enum values: `am` and `pm`.
+
+`leave_usage_days` is persisted because managers and listing screens need to show the amount of leave consumed without recalculating every row. Approval recalculates usage before deduction; if recalculated usage differs from the stored value, approval fails and the employee must resubmit.
+
+### leave_balances
+
+Balances remain stored and exposed in days:
+
+- `id`
+- `employee_id`
+- `leave_type`
+- `year`
+- `total_days`
+- `used_days`
+- timestamps
+
+Cross-year requests split usage by year. Each affected year must have a balance row for the requested leave type.
+
+## 3. Leave Usage Rules
+
+Leave is calculated from working sessions.
+
+A working day has two leave sessions:
+
+- `am` = 0.5 days
+- `pm` = 0.5 days
+
+Valid session ranges:
+
+- Same-day `am -> am`
+- Same-day `am -> pm`
+- Same-day `pm -> pm`
+- Multi-day `pm -> am`
+- Any multi-day combination where `start_date < end_date`
+
+Invalid session ranges:
+
+- `start_date > end_date`
+- Same-day `pm -> am`
+
+Working sessions exclude:
+
+- Saturdays
+- Sundays
+- Malaysia national public holidays from the `holidays` package
+
+If the selected range contains no working sessions, the request is rejected.
+
+## 4. Balance Rules
+
+The system uses a hybrid balance model:
+
+- Creating a leave request validates against available leave but does not deduct `used_days`.
+- Available leave means remaining balance after approved usage and pending requests.
+- Approving a leave request deducts from `used_days`.
+- Rejecting a leave request does not change balance.
+- Cancelling pending leave does not change balance.
+- Cancelling approved leave restores the deducted balance.
+
+Approval re-checks balance inside the approval workflow to protect against stale pending requests and concurrent approvals.
+
+Cross-year leave usage is split by leave year. For example, a request from `2026-12-31 pm` to `2027-01-02 pm` consumes the 2026 and 2027 balances separately.
+
+Missing yearly balance rows are validation failures. The leave workflow does not auto-create balances because entitlement creation is an HR setup concern.
+
+## 5. Overlap Rules
+
+Overlap validation is session-based.
+
+Two leave requests overlap when they belong to the same employee and include at least one identical working session.
+
+Statuses considered active:
+
+- `pending`
+- `approved`
+
+Statuses ignored for overlap:
+
+- `rejected`
+- `cancelled`
+
+Examples:
+
+- Existing `2026-06-10 am` does not block new `2026-06-10 pm`.
+- Existing `2026-06-10 am` blocks new `2026-06-10 am`.
+- A weekend-only selected range is rejected because it has no working sessions, not because of overlap.
+- A public-holiday-only selected range is rejected because it has no working sessions.
+
+## 6. Review and Cancellation Rules
+
+Only the employee's direct manager can approve or reject a leave request.
+
+Review transitions:
+
+- `pending -> approved`
+- `pending -> rejected`
+- `approved -> approved` is idempotent and does not deduct again.
+- `rejected -> rejected` is idempotent.
+
+Invalid review transitions:
+
+- `approved -> rejected`
+- `rejected -> approved`
+- `cancelled -> approved`
+- `cancelled -> rejected`
+
+Cancellation transitions:
+
+- `pending -> cancelled`
+- `approved -> cancelled`, only before the leave start date
+
+Rejected and cancelled leave requests are final.
+
+## 7. Edge Cases Identified
+
+- Half-day leave uses explicit `am` and `pm` sessions.
+- Full-day leave is represented as `am -> pm`, not as a separate API enum value.
+- Existing full-day API requests remain valid because session fields default to `am` and `pm`.
+- Weekend and Malaysia public holiday sessions do not consume leave.
+- Preview and create use the same leave usage calculator.
+- Pending requests block overlapping new requests.
+- Pending requests count against available leave but do not mutate balance.
+- Approved cancellation restores balance.
+- Same-decision review retries are idempotent.
+- Cross-year leave validates and deducts each leave year separately.
+- Missing balance rows reject the request rather than being auto-created.
+- Approval recalculates usage and rejects if holiday/calendar changes would alter the stored usage.
+
+## 8. Tradeoffs and Decisions
+
+### Expose days, calculate by sessions
+
+The API exposes leave usage and balances in days because that is the language employees and managers expect. Internally, the system reasons in half-day sessions so `0.5`, `1.5`, and cross-day ranges are unambiguous.
+
+### Use sessions instead of a `full_day` enum
+
+The API accepts only `am` and `pm` for sessions. A full day is represented by `start_session = "am"` and `end_session = "pm"`. This keeps overlap and duration calculation consistent because every request can be reduced to the same session model.
+
+### Use Malaysia national public holidays from a package
+
+The system uses the `holidays` package for Malaysia national public holidays instead of hardcoding dates. State-specific holidays are deferred because the current employee model has no work location, state, branch, or assigned leave calendar. This keeps the backend as the source of truth for leave usage and lets the frontend ask the backend for a usage preview.
+
+### Use direct-manager-only approval
+
+The current employee model has a `manager_id` but no roles or permission model. Direct-manager-only approval fits the existing model and avoids inventing admin or HR authority outside the challenge scope.
+
+### Reject changed usage on approval
+
+Leave usage is stored when the request is created, but approval recalculates usage before balance deduction. If the value changes, approval is rejected. This avoids silently deducting a different amount from what the employee submitted and what the manager reviewed.
+
+## 9. What I Would Do With More Time
+
+- Add company-specific holiday calendars and state-level Malaysia holiday configuration once employees have a work location or assigned leave calendar.
+- Add role-based approval rules for HR/admin overrides.
+- Add database-level protection for concurrent approvals, such as row locking or optimistic versioning.
+- Add audit events for approval, rejection, cancellation, and balance restoration.
+- Add a dedicated entitlement setup workflow for yearly leave balances.
+- Add calendar integration so approved leave can appear in shared calendars.
+
+## 10. Running the Project
+
+```bash
+# Install
+pip install -r requirements.txt
+
+# Run
+uvicorn src.app:app --reload
+
+# Test
+python -m pytest tests/
+```

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -80,7 +80,7 @@ Response body:
 }
 ```
 
-The preview endpoint does not create a leave request, reserve leave, or mutate balances. It exists so the frontend can show employees exactly how much leave their selected period would consume.
+The preview endpoint does not create a leave request, reserve leave, check balance availability, or mutate balances. It exists so the frontend can show employees exactly how much leave their selected period would consume.
 
 ### Review Leave Request
 
@@ -111,12 +111,12 @@ Expected status codes:
 POST /leave-requests/{leave_request_id}/cancel?employee_id=2
 ```
 
-Only the leave request owner can cancel. Pending leave can be cancelled without balance changes. Approved leave can be cancelled only before the leave start date, and cancellation restores the deducted balance.
+Only the employee who submitted the leave request can cancel through this endpoint. Pending leave can be cancelled without balance changes. Approved leave can be cancelled only before the leave start date, and cancellation restores the deducted balance. The service should derive "today" using the Malaysia timezone (`Asia/Kuala_Lumpur`), not the server's local timezone.
 
 Expected status codes:
 
 - `200 OK` when cancellation succeeds.
-- `422 Unprocessable Entity` when the employee is not the owner, the request is already rejected/cancelled, or the approved leave has started.
+- `422 Unprocessable Entity` when the employee is not the requester, the request is already rejected/cancelled, or the approved leave has started.
 - `404 Not Found` if the leave request does not exist.
 
 ### List Leave Requests
@@ -157,6 +157,8 @@ Balances are exposed in days:
 ]
 ```
 
+The API does not expose internal unit fields. Clients submit dates and sessions, and responses expose day values only.
+
 ## 2. Data Model
 
 ### employees
@@ -183,7 +185,7 @@ Leave requests should store the selected period and the calculated usage:
 - `start_session`
 - `end_date`
 - `end_session`
-- `leave_usage_days`
+- `leave_usage_units`
 - `reason`
 - `status`
 - `approved_by`
@@ -192,21 +194,34 @@ Leave requests should store the selected period and the calculated usage:
 
 `start_session` and `end_session` are enum values: `am` and `pm`.
 
-`leave_usage_days` is persisted because managers and listing screens need to show the amount of leave consumed without recalculating every row. Approval recalculates usage before deduction; if recalculated usage differs from the stored value, approval fails and the employee must resubmit.
+`leave_usage_units` is persisted as integer half-day units because managers and listing screens need to show the amount of leave consumed without recalculating every row, and integer storage avoids floating-point balance errors. The API converts units to `leave_usage_days`. Approval recalculates usage before deduction; if recalculated usage differs from the stored value, approval fails and the employee must resubmit.
+
+The storage column should be named `leave_usage_units`, not `leave_usage_days`, to avoid hiding unit-based persistence behind day-based terminology.
+
+Recommended index:
+
+- `(employee_id, status, start_date, end_date)` for overlap candidate queries.
 
 ### leave_balances
 
-Balances remain stored and exposed in days:
+Balances are stored internally as integer half-day units and exposed by the API in days:
 
 - `id`
 - `employee_id`
 - `leave_type`
 - `year`
-- `total_days`
-- `used_days`
+- `total_units`
+- `used_units`
 - timestamps
 
 Cross-year requests split usage by year. Each affected year must have a balance row for the requested leave type.
+
+The storage columns should be named `total_units` and `used_units`. Day-based fields such as `total_days`, `used_days`, and `remaining_days` are API-facing computed values.
+
+Recommended constraints and indexes:
+
+- Unique constraint on `(employee_id, leave_type, year)` to prevent duplicate yearly balances.
+- Index on `(employee_id, leave_type, year)` for balance lookup.
 
 ## 3. Leave Usage Rules
 
@@ -214,8 +229,8 @@ Leave is calculated from working sessions.
 
 A working day has two leave sessions:
 
-- `am` = 0.5 days
-- `pm` = 0.5 days
+- `am` = 1 unit = 0.5 days
+- `pm` = 1 unit = 0.5 days
 
 Valid session ranges:
 
@@ -229,6 +244,7 @@ Invalid session ranges:
 
 - `start_date > end_date`
 - Same-day `pm -> am`
+- `start_date < today`
 
 Working sessions exclude:
 
@@ -242,18 +258,26 @@ If the selected range contains no working sessions, the request is rejected.
 
 The system uses a hybrid balance model:
 
-- Creating a leave request validates against available leave but does not deduct `used_days`.
+- Creating a leave request validates against available leave but does not deduct `used_units`.
 - Available leave means remaining balance after approved usage and pending requests.
-- Approving a leave request deducts from `used_days`.
+- Approving a leave request deducts from `used_units`.
 - Rejecting a leave request does not change balance.
 - Cancelling pending leave does not change balance.
 - Cancelling approved leave restores the deducted balance.
 
 Approval re-checks balance inside the approval workflow to protect against stale pending requests and concurrent approvals.
 
+Mutation service functions should commit their own successful transactions so API routes and tests can call them directly. Approval and cancellation must update the leave request and related balance rows in the same transaction before committing.
+
+For this SQLite challenge app, concurrent approval protection is handled by re-checking request status, recalculated usage, and affected balances immediately before updating. In production with PostgreSQL, the approval workflow should lock the leave request and affected balance rows, or use optimistic version columns, so two managers cannot deduct the same balance concurrently.
+
 Cross-year leave usage is split by leave year. For example, a request from `2026-12-31 pm` to `2027-01-02 pm` consumes the 2026 and 2027 balances separately.
 
 Missing yearly balance rows are validation failures. The leave workflow does not auto-create balances because entitlement creation is an HR setup concern.
+
+Pending requests count against available leave using their stored `leave_usage_units`. For cross-year pending requests, services may recalculate the per-year split from the stored request dates and sessions because the request only stores total units. This avoids adding extra persistence for a rare case while keeping yearly balance validation correct.
+
+If recalculating a pending cross-year request produces a different total from its stored `leave_usage_units`, validation should fail with a stale leave usage conflict. The system should not silently reinterpret another pending request's reserved capacity after the employee has submitted it.
 
 ## 5. Overlap Rules
 
@@ -303,7 +327,42 @@ Cancellation transitions:
 
 Rejected and cancelled leave requests are final.
 
-## 7. Edge Cases Identified
+## 7. Error Handling
+
+The service layer should raise specific domain exception classes with a shared `LeaveError` base class. The FastAPI layer maps those exception types to user-friendly HTTP status codes.
+
+Recommended exception classes:
+
+- `EmployeeNotFoundError`
+- `LeaveRequestNotFoundError`
+- `InvalidLeavePeriodError`
+- `NoWorkingSessionsError`
+- `MissingLeaveBalanceError`
+- `InsufficientBalanceError`
+- `OverlappingLeaveError`
+- `InvalidStatusTransitionError`
+- `SelfApprovalError`
+- `ApprovalAuthorityError`
+- `CancellationAuthorityError`
+- `LeaveAlreadyStartedError`
+
+Recommended mapping:
+
+- Employee not found: `404 Not Found`
+- Leave request not found: `404 Not Found`
+- Approver not found: `404 Not Found`
+- Invalid date or session range: `422 Unprocessable Entity`
+- No working sessions in the selected range: `422 Unprocessable Entity`
+- Missing leave balance: `422 Unprocessable Entity`
+- Insufficient available leave: `422 Unprocessable Entity`
+- Overlapping leave: `409 Conflict`
+- Invalid status transition: `409 Conflict`
+- Self-approval: `403 Forbidden`
+- Non-manager approval: `403 Forbidden`
+- Non-requester cancellation: `403 Forbidden`
+- Approved leave already started: `409 Conflict`
+
+## 8. Edge Cases Identified
 
 - Half-day leave uses explicit `am` and `pm` sessions.
 - Full-day leave is represented as `am -> pm`, not as a separate API enum value.
@@ -317,12 +376,13 @@ Rejected and cancelled leave requests are final.
 - Cross-year leave validates and deducts each leave year separately.
 - Missing balance rows reject the request rather than being auto-created.
 - Approval recalculates usage and rejects if holiday/calendar changes would alter the stored usage.
+- Stale pending cross-year usage blocks new balance validation instead of being silently reinterpreted.
 
-## 8. Tradeoffs and Decisions
+## 9. Tradeoffs and Decisions
 
-### Expose days, calculate by sessions
+### Expose days, store integer units
 
-The API exposes leave usage and balances in days because that is the language employees and managers expect. Internally, the system reasons in half-day sessions so `0.5`, `1.5`, and cross-day ranges are unambiguous.
+The API exposes leave usage and balances in days because that is the language employees and managers expect. Internally, the system stores integer half-day units so `0.5`, `1.5`, and cross-day ranges are unambiguous and balance deduction avoids floating-point arithmetic.
 
 ### Use sessions instead of a `full_day` enum
 
@@ -340,16 +400,86 @@ The current employee model has a `manager_id` but no roles or permission model. 
 
 Leave usage is stored when the request is created, but approval recalculates usage before balance deduction. If the value changes, approval is rejected. This avoids silently deducting a different amount from what the employee submitted and what the manager reviewed.
 
-## 9. What I Would Do With More Time
+### Share calculation without overbuilding architecture
+
+Preview, create, overlap validation, and approval should use the same leave usage calculator so date/session/public-holiday rules cannot drift. This should be a small helper module, not a broad domain layer. The goal is to remove repeated complex calculation, not to introduce abstraction for its own sake.
+
+Date-sensitive service functions should derive the current date through a small Malaysia-timezone helper using `Asia/Kuala_Lumpur`. Those functions should accept an optional `today` parameter so tests can pass a fixed date without monkeypatching global time.
+
+### Derive working sessions instead of persisting them
+
+The system should not add a `leave_request_sessions` table for this challenge. Overlap validation should query only active leave requests whose raw date ranges could overlap, then derive working sessions from those candidates for exact session comparison. This keeps the schema simple while avoiding an employee-wide scan.
+
+## 10. What I Would Do With More Time
 
 - Add company-specific holiday calendars and state-level Malaysia holiday configuration once employees have a work location or assigned leave calendar.
 - Add role-based approval rules for HR/admin overrides.
+- Add administrative cancellation for HR or boss users once the system has an explicit role or permission model.
 - Add database-level protection for concurrent approvals, such as row locking or optimistic versioning.
 - Add audit events for approval, rejection, cancellation, and balance restoration.
 - Add a dedicated entitlement setup workflow for yearly leave balances.
 - Add calendar integration so approved leave can appear in shared calendars.
 
-## 10. Running the Project
+## 11. Test Plan
+
+Implementation should proceed with a TDD approach.
+
+Calculator tests:
+
+- Half-day AM leave consumes `0.5` days.
+- Half-day PM leave consumes `0.5` days.
+- Same-day full leave consumes `1.0` day.
+- Multi-day `pm -> am` leave is valid and consumes the expected sessions.
+- Same-day `pm -> am` leave is invalid.
+- Weekend sessions are excluded.
+- Malaysia national public holidays are excluded.
+- Cross-year leave returns usage split by year.
+- A range with no working sessions is rejected.
+
+Create request tests:
+
+- Missing sessions default to `am -> pm`.
+- Backdated `start_date` is rejected.
+- Missing employee is rejected.
+- Missing yearly balance is rejected.
+- Insufficient available leave is rejected.
+- Pending requests count against available leave.
+- Same-session overlap is rejected.
+- Different-session same-day leave is allowed.
+
+Preview tests:
+
+- Preview returns total usage, per-year usage, working sessions, and excluded dates.
+- Preview does not check balance availability.
+- Preview does not create requests or mutate balances.
+
+Review tests:
+
+- Direct manager can approve.
+- Non-manager approval is rejected.
+- Self-approval is rejected.
+- Approval deducts balance once.
+- Retrying the same approval is idempotent.
+- Retrying the same rejection is idempotent.
+- Changing a final decision is rejected.
+- Approval rejects stale leave usage if recalculation differs from stored usage.
+
+Cancellation tests:
+
+- Requester can cancel pending leave.
+- Requester can cancel approved future leave.
+- Cancelling approved leave restores balance.
+- Requester cannot cancel approved leave that has started.
+- Non-requester cancellation is rejected.
+- Rejected and cancelled leave requests cannot be cancelled again.
+
+Listing and balance tests:
+
+- Leave request filters work by employee, status, leave type, and date range.
+- Pagination returns items and total count.
+- Balance responses expose days converted from integer units.
+
+## 12. Running the Project
 
 ```bash
 # Install

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]>=0.29.0
 sqlalchemy>=2.0.0
 pytest>=8.0.0
 httpx>=0.27.0
+holidays>=0.57

--- a/src/app.py
+++ b/src/app.py
@@ -5,71 +5,112 @@ This is the entrypoint. Routes are defined but most business logic
 in services.py needs to be implemented to make everything work.
 """
 
-from datetime import date
+from contextlib import asynccontextmanager
+from datetime import date, datetime
 from typing import Optional
 
 from fastapi import FastAPI, Depends, HTTPException, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session
 
 from src.database import engine, get_db, Base
-from src.models import LeaveType, LeaveStatus
+from src.models import LeaveType, LeaveStatus, LeaveSession
 from src import services
 
 Base.metadata.create_all(bind=engine)
 
-app = FastAPI(title="Kakitangan Leave Management API", version="0.1.0")
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    db = next(get_db())
+    try:
+        services.seed_demo_data(db)
+        yield
+    finally:
+        db.close()
+
+
+app = FastAPI(title="Kakitangan Leave Management API", version="0.1.0", lifespan=lifespan)
+
+
+ERROR_STATUS_CODES = {
+    services.EmployeeNotFoundError: 404,
+    services.LeaveRequestNotFoundError: 404,
+    services.ApproverNotFoundError: 404,
+    services.OverlappingLeaveError: 409,
+    services.InvalidStatusTransitionError: 409,
+    services.StaleLeaveUsageError: 409,
+    services.LeaveAlreadyStartedError: 409,
+    services.SelfApprovalError: 403,
+    services.ApprovalAuthorityError: 403,
+    services.CancellationAuthorityError: 403,
+}
+
+
+def raise_leave_http_error(error: services.LeaveError) -> None:
+    raise HTTPException(status_code=ERROR_STATUS_CODES.get(type(error), 422), detail=str(error))
 
 
 # ── Schemas ──────────────────────────────────────────────────────────────
 
 class EmployeeOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     name: str
     email: str
     department: str
     manager_id: Optional[int] = None
 
-    class Config:
-        from_attributes = True
-
 
 class LeaveBalanceOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     leave_type: LeaveType
     year: int
     total_days: float
     used_days: float
     remaining_days: float
 
-    class Config:
-        from_attributes = True
-
 
 class LeaveRequestCreate(BaseModel):
     employee_id: int
     leave_type: LeaveType
     start_date: date
+    start_session: LeaveSession = LeaveSession.AM
     end_date: date
+    end_session: LeaveSession = LeaveSession.PM
     reason: Optional[str] = None
 
 
 class LeaveRequestOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     employee_id: int
     leave_type: LeaveType
     start_date: date
+    start_session: LeaveSession
     end_date: date
+    end_session: LeaveSession
+    leave_usage_days: float
     reason: Optional[str]
     status: LeaveStatus
     approved_by: Optional[int]
-    approved_at: Optional[str]
-
-    class Config:
-        from_attributes = True
+    approved_at: Optional[datetime]
 
 
 class LeaveRequestApprove(BaseModel):
     decision: LeaveStatus = Field(description="approved or rejected")
+
+
+class LeaveUsagePreviewCreate(BaseModel):
+    employee_id: int
+    leave_type: LeaveType
+    start_date: date
+    start_session: LeaveSession = LeaveSession.AM
+    end_date: date
+    end_session: LeaveSession = LeaveSession.PM
 
 
 class PaginatedLeaveRequests(BaseModel):
@@ -105,11 +146,47 @@ def create_leave_request(body: LeaveRequestCreate, db: Session = Depends(get_db)
     try:
         lr = services.create_leave_request(
             db, employee_id=body.employee_id, leave_type=body.leave_type,
-            start_date=body.start_date, end_date=body.end_date, reason=body.reason,
+            start_date=body.start_date, start_session=body.start_session,
+            end_date=body.end_date, end_session=body.end_session, reason=body.reason,
         )
         return lr
     except services.LeaveError as e:
-        raise HTTPException(status_code=422, detail=str(e))
+        raise_leave_http_error(e)
+
+
+@app.post("/leave-requests/preview")
+def preview_leave_usage(body: LeaveUsagePreviewCreate):
+    try:
+        usage = services.preview_leave_usage(
+            start_date=body.start_date,
+            start_session=body.start_session,
+            end_date=body.end_date,
+            end_session=body.end_session,
+        )
+        return {
+            "leave_usage_days": usage.total_days,
+            "leave_usage_by_year": {
+                str(year): units / 2 for year, units in usage.units_by_year.items()
+            },
+            "working_sessions": [
+                {
+                    "date": working_session.date,
+                    "sessions": [session.value for session in working_session.sessions],
+                    "days": working_session.days,
+                }
+                for working_session in usage.working_sessions
+            ],
+            "excluded_dates": [
+                {
+                    "date": excluded_date.date,
+                    "reason": excluded_date.reason,
+                    **({"name": excluded_date.name} if excluded_date.name else {}),
+                }
+                for excluded_date in usage.excluded_dates
+            ],
+        }
+    except services.LeaveError as e:
+        raise_leave_http_error(e)
 
 
 @app.get("/leave-requests", response_model=PaginatedLeaveRequests)
@@ -154,7 +231,7 @@ def review_leave_request(
         )
         return lr
     except services.LeaveError as e:
-        raise HTTPException(status_code=422, detail=str(e))
+        raise_leave_http_error(e)
 
 
 @app.post("/leave-requests/{leave_request_id}/cancel", response_model=LeaveRequestOut)
@@ -163,7 +240,7 @@ def cancel_leave_request(leave_request_id: int, employee_id: int = Query(...), d
         lr = services.cancel_leave_request(db, leave_request_id=leave_request_id, employee_id=employee_id)
         return lr
     except services.LeaveError as e:
-        raise HTTPException(status_code=422, detail=str(e))
+        raise_leave_http_error(e)
 
 
 @app.get("/leave-balances/{employee_id}", response_model=list[LeaveBalanceOut])
@@ -171,11 +248,3 @@ def get_balance(employee_id: int, year: Optional[int] = Query(None), db: Session
     balances = services.get_leave_balances(db, employee_id=employee_id, year=year)
     return [LeaveBalanceOut.model_validate(b) for b in balances]
 
-
-@app.on_event("startup")
-def on_startup():
-    db = next(get_db())
-    try:
-        services.seed_demo_data(db)
-    finally:
-        db.close()

--- a/src/leave_calculator.py
+++ b/src/leave_calculator.py
@@ -1,0 +1,107 @@
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+import holidays
+
+from src.models import LeaveSession
+
+
+@dataclass(frozen=True)
+class WorkingSession:
+    date: date
+    sessions: tuple[LeaveSession, ...]
+
+    @property
+    def units(self) -> int:
+        return len(self.sessions)
+
+    @property
+    def days(self) -> float:
+        return self.units / 2
+
+
+@dataclass(frozen=True)
+class ExcludedDate:
+    date: date
+    reason: str
+    name: str | None = None
+
+
+@dataclass(frozen=True)
+class LeaveUsageResult:
+    total_units: int
+    units_by_year: dict[int, int]
+    working_sessions: tuple[WorkingSession, ...]
+    excluded_dates: tuple[ExcludedDate, ...]
+
+    @property
+    def total_days(self) -> float:
+        return self.total_units / 2
+
+
+SESSION_ORDER = {
+    LeaveSession.AM: 0,
+    LeaveSession.PM: 1,
+}
+
+
+def calculate_leave_usage(
+    start_date: date,
+    start_session: LeaveSession,
+    end_date: date,
+    end_session: LeaveSession,
+) -> LeaveUsageResult:
+    years = range(start_date.year, end_date.year + 1)
+    malaysia_holidays = holidays.country_holidays("MY", years=years)
+    working_sessions: list[WorkingSession] = []
+    excluded_dates: list[ExcludedDate] = []
+
+    current_date = start_date
+    while current_date <= end_date:
+        if current_date.weekday() >= 5:
+            excluded_dates.append(ExcludedDate(date=current_date, reason="weekend"))
+        elif current_date in malaysia_holidays:
+            excluded_dates.append(
+                ExcludedDate(
+                    date=current_date,
+                    reason="public_holiday",
+                    name=str(malaysia_holidays[current_date]),
+                )
+            )
+        else:
+            sessions = _sessions_for_date(current_date, start_date, start_session, end_date, end_session)
+            if sessions:
+                working_sessions.append(WorkingSession(date=current_date, sessions=tuple(sessions)))
+
+        current_date += timedelta(days=1)
+
+    units_by_year: dict[int, int] = {}
+    for working_session in working_sessions:
+        units_by_year[working_session.date.year] = (
+            units_by_year.get(working_session.date.year, 0) + working_session.units
+        )
+
+    return LeaveUsageResult(
+        total_units=sum(units_by_year.values()),
+        units_by_year=units_by_year,
+        working_sessions=tuple(working_sessions),
+        excluded_dates=tuple(excluded_dates),
+    )
+
+
+def _sessions_for_date(
+    current_date: date,
+    start_date: date,
+    start_session: LeaveSession,
+    end_date: date,
+    end_session: LeaveSession,
+) -> list[LeaveSession]:
+    sessions = [LeaveSession.AM, LeaveSession.PM]
+
+    if current_date == start_date:
+        sessions = [session for session in sessions if SESSION_ORDER[session] >= SESSION_ORDER[start_session]]
+
+    if current_date == end_date:
+        sessions = [session for session in sessions if SESSION_ORDER[session] <= SESSION_ORDER[end_session]]
+
+    return sessions

--- a/src/models.py
+++ b/src/models.py
@@ -1,9 +1,13 @@
-from datetime import date, datetime
-from sqlalchemy import Column, Integer, String, Float, Date, DateTime, ForeignKey, Enum as SqlEnum
+from datetime import UTC, date, datetime
+from sqlalchemy import Column, Integer, String, Date, DateTime, ForeignKey, Enum as SqlEnum, Index, UniqueConstraint
 from sqlalchemy.orm import relationship
 import enum
 
 from src.database import Base
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC)
 
 
 class LeaveStatus(str, enum.Enum):
@@ -22,6 +26,11 @@ class LeaveType(str, enum.Enum):
     UNPAID = "unpaid"
 
 
+class LeaveSession(str, enum.Enum):
+    AM = "am"
+    PM = "pm"
+
+
 class Employee(Base):
     __tablename__ = "employees"
 
@@ -31,47 +40,73 @@ class Employee(Base):
     department = Column(String, nullable=False)
     manager_id = Column(Integer, ForeignKey("employees.id"), nullable=True)
     joined_at = Column(Date, default=date.today)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime, default=utc_now)
+    updated_at = Column(DateTime, default=utc_now, onupdate=utc_now)
 
     manager = relationship("Employee", remote_side="Employee.id")
-    leave_requests = relationship("LeaveRequest", back_populates="employee")
+    leave_requests = relationship(
+        "LeaveRequest",
+        back_populates="employee",
+        foreign_keys="LeaveRequest.employee_id",
+    )
     leave_balances = relationship("LeaveBalance", back_populates="employee")
 
 
 class LeaveRequest(Base):
     __tablename__ = "leave_requests"
+    __table_args__ = (
+        Index("ix_leave_requests_overlap_lookup", "employee_id", "status", "start_date", "end_date"),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     employee_id = Column(Integer, ForeignKey("employees.id"), nullable=False, index=True)
     leave_type = Column(SqlEnum(LeaveType), nullable=False)
     start_date = Column(Date, nullable=False)
+    start_session = Column(SqlEnum(LeaveSession), nullable=False, default=LeaveSession.AM)
     end_date = Column(Date, nullable=False)
+    end_session = Column(SqlEnum(LeaveSession), nullable=False, default=LeaveSession.PM)
+    leave_usage_units = Column(Integer, nullable=False)
     reason = Column(String, nullable=True)
     status = Column(SqlEnum(LeaveStatus), default=LeaveStatus.PENDING)
     approved_by = Column(Integer, ForeignKey("employees.id"), nullable=True)
     approved_at = Column(DateTime, nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime, default=utc_now)
+    updated_at = Column(DateTime, default=utc_now, onupdate=utc_now)
 
     employee = relationship("Employee", back_populates="leave_requests", foreign_keys=[employee_id])
     approver = relationship("Employee", foreign_keys=[approved_by])
 
+    @property
+    def leave_usage_days(self) -> float:
+        return self.leave_usage_units / 2
+
 
 class LeaveBalance(Base):
     __tablename__ = "leave_balances"
+    __table_args__ = (
+        UniqueConstraint("employee_id", "leave_type", "year", name="uq_leave_balances_employee_type_year"),
+        Index("ix_leave_balances_lookup", "employee_id", "leave_type", "year"),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     employee_id = Column(Integer, ForeignKey("employees.id"), nullable=False, index=True)
     leave_type = Column(SqlEnum(LeaveType), nullable=False)
     year = Column(Integer, nullable=False)
-    total_days = Column(Float, nullable=False, default=0)
-    used_days = Column(Float, nullable=False, default=0)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    total_units = Column(Integer, nullable=False, default=0)
+    used_units = Column(Integer, nullable=False, default=0)
+    created_at = Column(DateTime, default=utc_now)
+    updated_at = Column(DateTime, default=utc_now, onupdate=utc_now)
 
     employee = relationship("Employee", back_populates="leave_balances")
 
     @property
+    def total_days(self) -> float:
+        return self.total_units / 2
+
+    @property
+    def used_days(self) -> float:
+        return self.used_units / 2
+
+    @property
     def remaining_days(self) -> float:
-        return self.total_days - self.used_days
+        return (self.total_units - self.used_units) / 2

--- a/src/services.py
+++ b/src/services.py
@@ -8,10 +8,15 @@ Each function should raise appropriate exceptions for invalid operations
 
 from datetime import date, datetime
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 from sqlalchemy.orm import Session
 
-from src.models import Employee, LeaveRequest, LeaveBalance, LeaveType, LeaveStatus
+from src.leave_calculator import calculate_leave_usage
+from src.models import Employee, LeaveRequest, LeaveBalance, LeaveType, LeaveStatus, LeaveSession, utc_now
+
+
+MALAYSIA_TZ = ZoneInfo("Asia/Kuala_Lumpur")
 
 
 class LeaveError(Exception):
@@ -19,6 +24,22 @@ class LeaveError(Exception):
 
 
 class InsufficientBalanceError(LeaveError):
+    pass
+
+
+class EmployeeNotFoundError(LeaveError):
+    pass
+
+
+class InvalidLeavePeriodError(LeaveError):
+    pass
+
+
+class NoWorkingSessionsError(LeaveError):
+    pass
+
+
+class MissingLeaveBalanceError(LeaveError):
     pass
 
 
@@ -30,8 +51,40 @@ class SelfApprovalError(LeaveError):
     pass
 
 
+class LeaveRequestNotFoundError(LeaveError):
+    pass
+
+
+class ApproverNotFoundError(LeaveError):
+    pass
+
+
+class ApprovalAuthorityError(LeaveError):
+    pass
+
+
+class InvalidStatusTransitionError(LeaveError):
+    pass
+
+
+class StaleLeaveUsageError(LeaveError):
+    pass
+
+
 class CannotModifyApprovedLeaveError(LeaveError):
     pass
+
+
+class CancellationAuthorityError(LeaveError):
+    pass
+
+
+class LeaveAlreadyStartedError(LeaveError):
+    pass
+
+
+def malaysia_today() -> date:
+    return datetime.now(MALAYSIA_TZ).date()
 
 
 def create_leave_request(
@@ -40,7 +93,10 @@ def create_leave_request(
     leave_type: LeaveType,
     start_date: date,
     end_date: date,
+    start_session: LeaveSession = LeaveSession.AM,
+    end_session: LeaveSession = LeaveSession.PM,
     reason: Optional[str] = None,
+    today: Optional[date] = None,
 ) -> LeaveRequest:
     """
     Create a new leave request.
@@ -52,7 +108,72 @@ def create_leave_request(
     - Employee has sufficient leave balance for the requested type
     - end_date - start_date >= 0 (at least 1 day — or handle half-day logic)
     """
-    raise NotImplementedError("Candidate must implement this")
+    today = today or malaysia_today()
+    employee = db.query(Employee).filter(Employee.id == employee_id).first()
+    if not employee:
+        raise EmployeeNotFoundError("Employee not found")
+
+    if start_date > end_date:
+        raise InvalidLeavePeriodError("Start date must be on or before end date")
+
+    if start_date < today:
+        raise InvalidLeavePeriodError("Leave request cannot be backdated")
+
+    if start_date == end_date and start_session == LeaveSession.PM and end_session == LeaveSession.AM:
+        raise InvalidLeavePeriodError("End session cannot be earlier than start session on the same day")
+
+    usage = calculate_leave_usage(start_date, start_session, end_date, end_session)
+    if usage.total_units == 0:
+        raise NoWorkingSessionsError("Leave request must include at least one working session")
+
+    pending_requests = _pending_requests_for_balance(db, employee_id, leave_type)
+    for year, requested_units in usage.units_by_year.items():
+        balance = _get_balance(db, employee_id, leave_type, year)
+        if not balance:
+            raise MissingLeaveBalanceError(f"Leave balance not found for {leave_type.value} leave in {year}")
+
+        pending_units = _pending_units_for_year(pending_requests, year)
+        available_units = balance.total_units - balance.used_units - pending_units
+        if requested_units > available_units:
+            raise InsufficientBalanceError("Insufficient leave balance")
+
+    _ensure_no_overlap(db, employee_id, start_date, end_date, usage)
+
+    leave_request = LeaveRequest(
+        employee_id=employee_id,
+        leave_type=leave_type,
+        start_date=start_date,
+        start_session=start_session,
+        end_date=end_date,
+        end_session=end_session,
+        leave_usage_units=usage.total_units,
+        reason=reason,
+        status=LeaveStatus.PENDING,
+    )
+    db.add(leave_request)
+    db.commit()
+    db.refresh(leave_request)
+
+    return leave_request
+
+
+def preview_leave_usage(
+    start_date: date,
+    end_date: date,
+    start_session: LeaveSession = LeaveSession.AM,
+    end_session: LeaveSession = LeaveSession.PM,
+):
+    if start_date > end_date:
+        raise InvalidLeavePeriodError("Start date must be on or before end date")
+
+    if start_date == end_date and start_session == LeaveSession.PM and end_session == LeaveSession.AM:
+        raise InvalidLeavePeriodError("End session cannot be earlier than start session on the same day")
+
+    usage = calculate_leave_usage(start_date, start_session, end_date, end_session)
+    if usage.total_units == 0:
+        raise NoWorkingSessionsError("Leave request must include at least one working session")
+
+    return usage
 
 
 def approve_leave_request(
@@ -70,13 +191,69 @@ def approve_leave_request(
     - On approval: deduct from leave balance
     - On rejection: record reason in comment field if needed
     """
-    raise NotImplementedError("Candidate must implement this")
+    if decision not in {LeaveStatus.APPROVED, LeaveStatus.REJECTED}:
+        raise InvalidStatusTransitionError("Review decision must be approved or rejected")
+
+    leave_request = db.query(LeaveRequest).filter(LeaveRequest.id == leave_request_id).first()
+    if not leave_request:
+        raise LeaveRequestNotFoundError("Leave request not found")
+
+    approver = db.query(Employee).filter(Employee.id == approver_id).first()
+    if not approver:
+        raise ApproverNotFoundError("Approver not found")
+
+    if leave_request.employee_id == approver_id:
+        raise SelfApprovalError("Employees cannot approve their own leave requests")
+
+    employee = db.query(Employee).filter(Employee.id == leave_request.employee_id).first()
+    if employee.manager_id != approver_id:
+        raise ApprovalAuthorityError("Only the employee's direct manager can review this leave request")
+
+    if leave_request.status == decision:
+        return leave_request
+
+    if leave_request.status != LeaveStatus.PENDING:
+        raise InvalidStatusTransitionError("Only pending leave requests can be reviewed")
+
+    if decision == LeaveStatus.REJECTED:
+        leave_request.status = LeaveStatus.REJECTED
+        db.commit()
+        db.refresh(leave_request)
+        return leave_request
+
+    usage = calculate_leave_usage(
+        leave_request.start_date,
+        leave_request.start_session,
+        leave_request.end_date,
+        leave_request.end_session,
+    )
+    if usage.total_units != leave_request.leave_usage_units:
+        raise StaleLeaveUsageError("Leave usage has changed since submission")
+
+    for year, requested_units in usage.units_by_year.items():
+        balance = _get_balance(db, leave_request.employee_id, leave_request.leave_type, year)
+        if not balance:
+            raise MissingLeaveBalanceError(f"Leave balance not found for {leave_request.leave_type.value} leave in {year}")
+
+        if requested_units > balance.total_units - balance.used_units:
+            raise InsufficientBalanceError("Insufficient leave balance")
+
+        balance.used_units += requested_units
+
+    leave_request.status = LeaveStatus.APPROVED
+    leave_request.approved_by = approver_id
+    leave_request.approved_at = utc_now()
+    db.commit()
+    db.refresh(leave_request)
+
+    return leave_request
 
 
 def cancel_leave_request(
     db: Session,
     leave_request_id: int,
     employee_id: int,
+    today: Optional[date] = None,
 ) -> LeaveRequest:
     """
     Cancel a leave request.
@@ -84,7 +261,49 @@ def cancel_leave_request(
     - Can only cancel PENDING or APPROVED leaves
     - Cancelling an approved leave restores balance
     """
-    raise NotImplementedError("Candidate must implement this")
+    today = today or malaysia_today()
+    leave_request = db.query(LeaveRequest).filter(LeaveRequest.id == leave_request_id).first()
+    if not leave_request:
+        raise LeaveRequestNotFoundError("Leave request not found")
+
+    if leave_request.employee_id != employee_id:
+        raise CancellationAuthorityError("Only the requester can cancel this leave request")
+
+    if leave_request.status == LeaveStatus.CANCELLED:
+        raise InvalidStatusTransitionError("Leave request is already cancelled")
+
+    if leave_request.status == LeaveStatus.REJECTED:
+        raise InvalidStatusTransitionError("Rejected leave requests cannot be cancelled")
+
+    if leave_request.status == LeaveStatus.APPROVED:
+        if leave_request.start_date <= today:
+            raise LeaveAlreadyStartedError("Approved leave that has started cannot be cancelled")
+
+        usage = calculate_leave_usage(
+            leave_request.start_date,
+            leave_request.start_session,
+            leave_request.end_date,
+            leave_request.end_session,
+        )
+        if usage.total_units != leave_request.leave_usage_units:
+            raise StaleLeaveUsageError("Leave usage has changed since submission")
+
+        for year, used_units in usage.units_by_year.items():
+            balance = _get_balance(db, leave_request.employee_id, leave_request.leave_type, year)
+            if not balance:
+                raise MissingLeaveBalanceError(
+                    f"Leave balance not found for {leave_request.leave_type.value} leave in {year}"
+                )
+            balance.used_units -= used_units
+
+    if leave_request.status != LeaveStatus.PENDING and leave_request.status != LeaveStatus.APPROVED:
+        raise InvalidStatusTransitionError("Only pending or approved leave requests can be cancelled")
+
+    leave_request.status = LeaveStatus.CANCELLED
+    db.commit()
+    db.refresh(leave_request)
+
+    return leave_request
 
 
 def get_leave_requests(
@@ -95,13 +314,38 @@ def get_leave_requests(
     from_date: Optional[date] = None,
     to_date: Optional[date] = None,
     page: int = 1,
-    page_size: int = 20,
+    page_size: int = 1,
 ) -> tuple[list[LeaveRequest], int]:
     """
     List leave requests with filtering and pagination.
     Returns (items, total_count).
     """
-    raise NotImplementedError("Candidate must implement this")
+    query = db.query(LeaveRequest)
+
+    if employee_id is not None:
+        query = query.filter(LeaveRequest.employee_id == employee_id)
+
+    if status is not None:
+        query = query.filter(LeaveRequest.status == status)
+
+    if leave_type is not None:
+        query = query.filter(LeaveRequest.leave_type == leave_type)
+
+    if from_date is not None:
+        query = query.filter(LeaveRequest.end_date >= from_date)
+
+    if to_date is not None:
+        query = query.filter(LeaveRequest.start_date <= to_date)
+
+    total = query.count()
+    items = (
+        query.order_by(LeaveRequest.start_date, LeaveRequest.id)
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+
+    return items, total
 
 
 def get_leave_balances(
@@ -112,7 +356,91 @@ def get_leave_balances(
     """
     Get leave balances for an employee for a given year (defaults to current year).
     """
-    raise NotImplementedError("Candidate must implement this")
+    year = year or malaysia_today().year
+
+    return (
+        db.query(LeaveBalance)
+        .filter(
+            LeaveBalance.employee_id == employee_id,
+            LeaveBalance.year == year,
+        )
+        .order_by(LeaveBalance.leave_type)
+        .all()
+    )
+
+
+def _get_balance(db: Session, employee_id: int, leave_type: LeaveType, year: int) -> Optional[LeaveBalance]:
+    return (
+        db.query(LeaveBalance)
+        .filter(
+            LeaveBalance.employee_id == employee_id,
+            LeaveBalance.leave_type == leave_type,
+            LeaveBalance.year == year,
+        )
+        .first()
+    )
+
+
+def _ensure_no_overlap(db: Session, employee_id: int, start_date: date, end_date: date, usage) -> None:
+    requested_sessions = _session_keys(usage)
+    candidates = (
+        db.query(LeaveRequest)
+        .filter(
+            LeaveRequest.employee_id == employee_id,
+            LeaveRequest.status.in_([LeaveStatus.PENDING, LeaveStatus.APPROVED]),
+            LeaveRequest.start_date <= end_date,
+            LeaveRequest.end_date >= start_date,
+        )
+        .all()
+    )
+
+    for candidate in candidates:
+        candidate_usage = calculate_leave_usage(
+            candidate.start_date,
+            candidate.start_session,
+            candidate.end_date,
+            candidate.end_session,
+        )
+        if requested_sessions.intersection(_session_keys(candidate_usage)):
+            raise OverlappingLeaveError("Leave request overlaps with an active leave request")
+
+
+def _session_keys(usage) -> set[tuple[date, LeaveSession]]:
+    return {
+        (working_session.date, session)
+        for working_session in usage.working_sessions
+        for session in working_session.sessions
+    }
+
+
+def _pending_units_for_year(pending_requests: list[LeaveRequest], year: int) -> int:
+    total_units = 0
+    for pending_request in pending_requests:
+        if pending_request.start_date.year == year and pending_request.end_date.year == year:
+            total_units += pending_request.leave_usage_units
+            continue
+
+        usage = calculate_leave_usage(
+            pending_request.start_date,
+            pending_request.start_session,
+            pending_request.end_date,
+            pending_request.end_session,
+        )
+        total_units += usage.units_by_year.get(year, 0)
+
+    return total_units
+
+
+def _pending_requests_for_balance(db: Session, employee_id: int, leave_type: LeaveType) -> list[LeaveRequest]:
+    return (
+        db.query(LeaveRequest)
+        .filter(
+            LeaveRequest.employee_id == employee_id,
+            LeaveRequest.leave_type == leave_type,
+            LeaveRequest.status == LeaveStatus.PENDING,
+        )
+        .all()
+    )
 
 
 def seed_demo_data(db: Session) -> None:
@@ -131,10 +459,10 @@ def seed_demo_data(db: Session) -> None:
 
     year = date.today().year
     balances = [
-        LeaveBalance(employee_id=bob.id, leave_type=LeaveType.ANNUAL, year=year, total_days=14),
-        LeaveBalance(employee_id=bob.id, leave_type=LeaveType.SICK, year=year, total_days=12),
-        LeaveBalance(employee_id=carol.id, leave_type=LeaveType.ANNUAL, year=year, total_days=14),
-        LeaveBalance(employee_id=carol.id, leave_type=LeaveType.SICK, year=year, total_days=12),
+        LeaveBalance(employee_id=bob.id, leave_type=LeaveType.ANNUAL, year=year, total_units=28),
+        LeaveBalance(employee_id=bob.id, leave_type=LeaveType.SICK, year=year, total_units=24),
+        LeaveBalance(employee_id=carol.id, leave_type=LeaveType.ANNUAL, year=year, total_units=28),
+        LeaveBalance(employee_id=carol.id, leave_type=LeaveType.SICK, year=year, total_units=24),
     ]
     db.add_all(balances)
     db.commit()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,15 +7,43 @@ with real tests once you implement src/services.py.
 """
 
 import unittest
-from fastapi.testclient import TestClient
 
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.database import Base, get_db
 from src.app import app
+from src.services import seed_demo_data
 
 
 class TestLeaveAPI(unittest.TestCase):
 
     def setUp(self):
+        self.engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(bind=self.engine)
+        self.Session = sessionmaker(autocommit=False, autoflush=False, bind=self.engine)
+        self.db = self.Session()
+        seed_demo_data(self.db)
+
+        def override_get_db():
+            try:
+                yield self.db
+            finally:
+                pass
+
+        app.dependency_overrides[get_db] = override_get_db
         self.client = TestClient(app)
+
+    def tearDown(self):
+        app.dependency_overrides.clear()
+        self.db.close()
+        Base.metadata.drop_all(bind=self.engine)
 
     def test_list_employees(self):
         resp = self.client.get("/employees")
@@ -31,14 +59,65 @@ class TestLeaveAPI(unittest.TestCase):
         resp = self.client.post("/leave-requests", json={
             "employee_id": 2,
             "leave_type": "annual",
-            "start_date": str(date.today() + timedelta(days=7)),
-            "end_date": str(date.today() + timedelta(days=9)),
+            "start_date": "2026-06-10",
+            "end_date": "2026-06-10",
         })
-        # Without service implementation, expect 422 or 500
-        self.assertIn(resp.status_code, (201, 422, 500))
 
+        self.assertEqual(resp.status_code, 201)
+        body = resp.json()
+        self.assertEqual(body["status"], "pending")
+        self.assertEqual(body["start_session"], "am")
+        self.assertEqual(body["end_session"], "pm")
+        self.assertEqual(body["leave_usage_days"], 1.0)
 
-from datetime import date, timedelta
+    def test_preview_leave_usage(self):
+        resp = self.client.post("/leave-requests/preview", json={
+            "employee_id": 2,
+            "leave_type": "annual",
+            "start_date": "2026-06-10",
+            "end_date": "2026-06-10",
+        })
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["leave_usage_days"], 1.0)
+        self.assertEqual(body["leave_usage_by_year"], {"2026": 1.0})
+        self.assertEqual(body["working_sessions"], [
+            {"date": "2026-06-10", "sessions": ["am", "pm"], "days": 1.0}
+        ])
+        self.assertEqual(body["excluded_dates"], [])
+
+    def test_overlapping_leave_request_returns_conflict(self):
+        payload = {
+            "employee_id": 2,
+            "leave_type": "annual",
+            "start_date": "2026-06-10",
+            "end_date": "2026-06-10",
+        }
+        first_resp = self.client.post("/leave-requests", json=payload)
+        self.assertEqual(first_resp.status_code, 201)
+
+        second_resp = self.client.post("/leave-requests", json=payload)
+
+        self.assertEqual(second_resp.status_code, 409)
+        self.assertIn("overlaps", second_resp.json()["detail"])
+
+    def test_list_leave_requests_includes_leave_usage_days(self):
+        create_resp = self.client.post("/leave-requests", json={
+            "employee_id": 2,
+            "leave_type": "annual",
+            "start_date": "2026-06-10",
+            "end_date": "2026-06-10",
+        })
+        self.assertEqual(create_resp.status_code, 201)
+
+        list_resp = self.client.get("/leave-requests?employee_id=2&page_size=1")
+
+        self.assertEqual(list_resp.status_code, 200)
+        body = list_resp.json()
+        self.assertEqual(body["total"], 1)
+        self.assertEqual(body["page_size"], 1)
+        self.assertEqual(body["items"][0]["leave_usage_days"], 1.0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -13,13 +13,13 @@ Consider:
 """
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from src.database import Base
-from src.models import LeaveType, LeaveStatus
+from src.models import LeaveBalance, LeaveType, LeaveStatus, LeaveSession
 from src.services import (
     seed_demo_data,
     create_leave_request,
@@ -30,6 +30,11 @@ from src.services import (
     InsufficientBalanceError,
     OverlappingLeaveError,
     SelfApprovalError,
+    InvalidLeavePeriodError,
+    NoWorkingSessionsError,
+    MissingLeaveBalanceError,
+    ApprovalAuthorityError,
+    InvalidStatusTransitionError,
 )
 
 
@@ -44,6 +49,8 @@ class TestLeaveServices(unittest.TestCase):
 
     def setUp(self):
         self.db = self.Session()
+        Base.metadata.drop_all(bind=self.db.get_bind())
+        Base.metadata.create_all(bind=self.db.get_bind())
         seed_demo_data(self.db)
         # Fetch demo employees
         from src.models import Employee
@@ -55,36 +62,462 @@ class TestLeaveServices(unittest.TestCase):
         self.db.close()
 
     def test_create_leave_request(self):
-        # TODO: implement
-        self.assertTrue(True)
+        leave_request = create_leave_request(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            start_date=date(2026, 6, 10),
+            end_date=date(2026, 6, 10),
+            today=date(2026, 6, 1),
+        )
+
+        self.assertEqual(leave_request.status, LeaveStatus.PENDING)
+        self.assertEqual(leave_request.start_session, LeaveSession.AM)
+        self.assertEqual(leave_request.end_session, LeaveSession.PM)
+        self.assertEqual(leave_request.leave_usage_units, 2)
+
+        balances = get_leave_balances(self.db, employee_id=self.bob.id, year=2026)
+        annual_balance = next(b for b in balances if b.leave_type == LeaveType.ANNUAL)
+        self.assertEqual(annual_balance.total_units, 28)
+        self.assertEqual(annual_balance.used_units, 0)
+        self.assertEqual(annual_balance.remaining_days, 14.0)
 
     def test_create_leave_request_insufficient_balance(self):
-        # TODO: implement
-        self.assertTrue(True)
+        annual_balance = next(
+            balance
+            for balance in get_leave_balances(self.db, employee_id=self.bob.id, year=2026)
+            if balance.leave_type == LeaveType.ANNUAL
+        )
+        annual_balance.total_units = 2
+        self.db.commit()
+
+        create_leave_request(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            start_date=date(2026, 6, 10),
+            end_date=date(2026, 6, 10),
+            start_session=LeaveSession.AM,
+            end_session=LeaveSession.AM,
+            today=date(2026, 6, 1),
+        )
+
+        with self.assertRaises(InsufficientBalanceError):
+            create_leave_request(
+                self.db,
+                employee_id=self.bob.id,
+                leave_type=LeaveType.ANNUAL,
+                start_date=date(2026, 6, 11),
+                end_date=date(2026, 6, 11),
+                today=date(2026, 6, 1),
+            )
+
+    def test_create_leave_request_rejects_missing_balance_year(self):
+        with self.assertRaises(MissingLeaveBalanceError):
+            create_leave_request(
+                self.db,
+                employee_id=self.bob.id,
+                leave_type=LeaveType.ANNUAL,
+                start_date=date(2027, 1, 5),
+                end_date=date(2027, 1, 5),
+                today=date(2026, 12, 1),
+            )
+
+    def test_create_leave_request_rejects_backdated_start_date(self):
+        with self.assertRaises(InvalidLeavePeriodError):
+            create_leave_request(
+                self.db,
+                employee_id=self.bob.id,
+                leave_type=LeaveType.ANNUAL,
+                start_date=date(2026, 5, 31),
+                end_date=date(2026, 6, 1),
+                today=date(2026, 6, 1),
+            )
 
     def test_create_leave_request_overlapping_dates(self):
-        # TODO: implement
-        self.assertTrue(True)
+        create_leave_request(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            start_date=date(2026, 6, 10),
+            end_date=date(2026, 6, 10),
+            start_session=LeaveSession.AM,
+            end_session=LeaveSession.AM,
+            today=date(2026, 6, 1),
+        )
+
+        with self.assertRaises(OverlappingLeaveError):
+            create_leave_request(
+                self.db,
+                employee_id=self.bob.id,
+                leave_type=LeaveType.ANNUAL,
+                start_date=date(2026, 6, 10),
+                end_date=date(2026, 6, 10),
+                start_session=LeaveSession.AM,
+                end_session=LeaveSession.AM,
+                today=date(2026, 6, 1),
+            )
+
+    def test_create_leave_request_allows_different_session_same_day(self):
+        morning_leave = create_leave_request(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            start_date=date(2026, 6, 10),
+            end_date=date(2026, 6, 10),
+            start_session=LeaveSession.AM,
+            end_session=LeaveSession.AM,
+            today=date(2026, 6, 1),
+        )
+        afternoon_leave = create_leave_request(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            start_date=date(2026, 6, 10),
+            end_date=date(2026, 6, 10),
+            start_session=LeaveSession.PM,
+            end_session=LeaveSession.PM,
+            today=date(2026, 6, 1),
+        )
+
+        self.assertEqual(morning_leave.leave_usage_units, 1)
+        self.assertEqual(afternoon_leave.leave_usage_units, 1)
+
+    def test_create_leave_request_rejects_invalid_or_non_working_periods(self):
+        with self.assertRaises(InvalidLeavePeriodError):
+            create_leave_request(
+                self.db,
+                employee_id=self.bob.id,
+                leave_type=LeaveType.ANNUAL,
+                start_date=date(2026, 6, 10),
+                end_date=date(2026, 6, 10),
+                start_session=LeaveSession.PM,
+                end_session=LeaveSession.AM,
+                today=date(2026, 6, 1),
+            )
+
+        with self.assertRaises(NoWorkingSessionsError):
+            create_leave_request(
+                self.db,
+                employee_id=self.bob.id,
+                leave_type=LeaveType.ANNUAL,
+                start_date=date(2026, 6, 13),
+                end_date=date(2026, 6, 14),
+                today=date(2026, 6, 1),
+            )
+
+    def test_create_leave_request_counts_half_day_boundaries(self):
+        am_leave = create_leave_request(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            start_date=date(2026, 6, 10),
+            end_date=date(2026, 6, 10),
+            start_session=LeaveSession.AM,
+            end_session=LeaveSession.AM,
+            today=date(2026, 6, 1),
+        )
+        pm_leave = create_leave_request(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            start_date=date(2026, 6, 11),
+            end_date=date(2026, 6, 11),
+            start_session=LeaveSession.PM,
+            end_session=LeaveSession.PM,
+            today=date(2026, 6, 1),
+        )
+        full_day_leave = create_leave_request(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            start_date=date(2026, 6, 12),
+            end_date=date(2026, 6, 12),
+            start_session=LeaveSession.AM,
+            end_session=LeaveSession.PM,
+            today=date(2026, 6, 1),
+        )
+
+        self.assertEqual(am_leave.leave_usage_days, 0.5)
+        self.assertEqual(pm_leave.leave_usage_days, 0.5)
+        self.assertEqual(full_day_leave.leave_usage_days, 1.0)
+
+    def test_create_leave_request_excludes_holiday_from_mixed_range(self):
+        leave_request = create_leave_request(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            start_date=date(2026, 8, 31),
+            end_date=date(2026, 9, 1),
+            today=date(2026, 8, 1),
+        )
+
+        self.assertEqual(leave_request.leave_usage_units, 2)
+        self.assertEqual(leave_request.leave_usage_days, 1.0)
+
+    def test_create_leave_request_splits_cross_year_usage_on_approval(self):
+        self.db.add(LeaveBalance(employee_id=self.bob.id, leave_type=LeaveType.ANNUAL, year=2027, total_units=28))
+        self.db.commit()
+        leave_request = create_leave_request(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            start_date=date(2026, 12, 31),
+            end_date=date(2027, 1, 2),
+            start_session=LeaveSession.PM,
+            end_session=LeaveSession.PM,
+            today=date(2026, 12, 1),
+        )
+
+        self.assertEqual(leave_request.leave_usage_units, 3)
+
+        approve_leave_request(
+            self.db,
+            leave_request_id=leave_request.id,
+            approver_id=self.alice.id,
+            decision=LeaveStatus.APPROVED,
+        )
+
+        balances_2026 = get_leave_balances(self.db, employee_id=self.bob.id, year=2026)
+        balances_2027 = get_leave_balances(self.db, employee_id=self.bob.id, year=2027)
+        annual_2026 = next(balance for balance in balances_2026 if balance.leave_type == LeaveType.ANNUAL)
+        annual_2027 = next(balance for balance in balances_2027 if balance.leave_type == LeaveType.ANNUAL)
+        self.assertEqual(annual_2026.used_units, 1)
+        self.assertEqual(annual_2027.used_units, 2)
 
     def test_approve_leave_request(self):
-        # TODO: implement
-        self.assertTrue(True)
+        leave_request = create_leave_request(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            start_date=date(2026, 6, 10),
+            end_date=date(2026, 6, 10),
+            today=date(2026, 6, 1),
+        )
+
+        reviewed = approve_leave_request(
+            self.db,
+            leave_request_id=leave_request.id,
+            approver_id=self.alice.id,
+            decision=LeaveStatus.APPROVED,
+        )
+
+        self.assertEqual(reviewed.status, LeaveStatus.APPROVED)
+        self.assertEqual(reviewed.approved_by, self.alice.id)
+        self.assertIsNotNone(reviewed.approved_at)
+
+        annual_balance = next(
+            balance
+            for balance in get_leave_balances(self.db, employee_id=self.bob.id, year=2026)
+            if balance.leave_type == LeaveType.ANNUAL
+        )
+        self.assertEqual(annual_balance.used_units, 2)
+        self.assertEqual(annual_balance.remaining_days, 13.0)
+
+    def test_approve_leave_request_is_idempotent_for_same_decision(self):
+        leave_request = create_leave_request(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            start_date=date(2026, 6, 10),
+            end_date=date(2026, 6, 10),
+            today=date(2026, 6, 1),
+        )
+
+        approve_leave_request(
+            self.db,
+            leave_request_id=leave_request.id,
+            approver_id=self.alice.id,
+            decision=LeaveStatus.APPROVED,
+        )
+        approve_leave_request(
+            self.db,
+            leave_request_id=leave_request.id,
+            approver_id=self.alice.id,
+            decision=LeaveStatus.APPROVED,
+        )
+
+        annual_balance = next(
+            balance
+            for balance in get_leave_balances(self.db, employee_id=self.bob.id, year=2026)
+            if balance.leave_type == LeaveType.ANNUAL
+        )
+        self.assertEqual(annual_balance.used_units, 2)
+
+    def test_reject_leave_request_does_not_change_balance_and_is_idempotent(self):
+        leave_request = create_leave_request(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            start_date=date(2026, 6, 10),
+            end_date=date(2026, 6, 10),
+            today=date(2026, 6, 1),
+        )
+
+        rejected = approve_leave_request(
+            self.db,
+            leave_request_id=leave_request.id,
+            approver_id=self.alice.id,
+            decision=LeaveStatus.REJECTED,
+        )
+        rejected_again = approve_leave_request(
+            self.db,
+            leave_request_id=leave_request.id,
+            approver_id=self.alice.id,
+            decision=LeaveStatus.REJECTED,
+        )
+
+        self.assertEqual(rejected.status, LeaveStatus.REJECTED)
+        self.assertEqual(rejected_again.status, LeaveStatus.REJECTED)
+        annual_balance = next(
+            balance
+            for balance in get_leave_balances(self.db, employee_id=self.bob.id, year=2026)
+            if balance.leave_type == LeaveType.ANNUAL
+        )
+        self.assertEqual(annual_balance.used_units, 0)
+
+    def test_non_manager_approval_rejected(self):
+        leave_request = create_leave_request(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            start_date=date(2026, 6, 10),
+            end_date=date(2026, 6, 10),
+            today=date(2026, 6, 1),
+        )
+
+        with self.assertRaises(ApprovalAuthorityError):
+            approve_leave_request(
+                self.db,
+                leave_request_id=leave_request.id,
+                approver_id=self.carol.id,
+                decision=LeaveStatus.APPROVED,
+            )
 
     def test_self_approval_rejected(self):
-        # TODO: implement
-        self.assertTrue(True)
+        leave_request = create_leave_request(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            start_date=date(2026, 6, 10),
+            end_date=date(2026, 6, 10),
+            today=date(2026, 6, 1),
+        )
+
+        with self.assertRaises(SelfApprovalError):
+            approve_leave_request(
+                self.db,
+                leave_request_id=leave_request.id,
+                approver_id=self.bob.id,
+                decision=LeaveStatus.APPROVED,
+            )
 
     def test_cancel_approved_leave_restores_balance(self):
-        # TODO: implement
-        self.assertTrue(True)
+        leave_request = create_leave_request(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            start_date=date(2026, 6, 10),
+            end_date=date(2026, 6, 10),
+            today=date(2026, 6, 1),
+        )
+        approve_leave_request(
+            self.db,
+            leave_request_id=leave_request.id,
+            approver_id=self.alice.id,
+            decision=LeaveStatus.APPROVED,
+        )
+
+        cancelled = cancel_leave_request(
+            self.db,
+            leave_request_id=leave_request.id,
+            employee_id=self.bob.id,
+            today=date(2026, 6, 1),
+        )
+
+        self.assertEqual(cancelled.status, LeaveStatus.CANCELLED)
+        annual_balance = next(
+            balance
+            for balance in get_leave_balances(self.db, employee_id=self.bob.id, year=2026)
+            if balance.leave_type == LeaveType.ANNUAL
+        )
+        self.assertEqual(annual_balance.used_units, 0)
+        self.assertEqual(annual_balance.remaining_days, 14.0)
+
+    def test_cancel_pending_leave_does_not_change_balance_and_cannot_repeat(self):
+        leave_request = create_leave_request(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            start_date=date(2026, 6, 10),
+            end_date=date(2026, 6, 10),
+            today=date(2026, 6, 1),
+        )
+
+        cancelled = cancel_leave_request(
+            self.db,
+            leave_request_id=leave_request.id,
+            employee_id=self.bob.id,
+            today=date(2026, 6, 1),
+        )
+
+        self.assertEqual(cancelled.status, LeaveStatus.CANCELLED)
+        annual_balance = next(
+            balance
+            for balance in get_leave_balances(self.db, employee_id=self.bob.id, year=2026)
+            if balance.leave_type == LeaveType.ANNUAL
+        )
+        self.assertEqual(annual_balance.used_units, 0)
+
+        with self.assertRaises(InvalidStatusTransitionError):
+            cancel_leave_request(
+                self.db,
+                leave_request_id=leave_request.id,
+                employee_id=self.bob.id,
+                today=date(2026, 6, 1),
+            )
 
     def test_list_leave_requests_with_filters(self):
-        # TODO: implement
-        self.assertTrue(True)
+        annual_request = create_leave_request(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            start_date=date(2026, 6, 10),
+            end_date=date(2026, 6, 10),
+            today=date(2026, 6, 1),
+        )
+        create_leave_request(
+            self.db,
+            employee_id=self.carol.id,
+            leave_type=LeaveType.SICK,
+            start_date=date(2026, 6, 11),
+            end_date=date(2026, 6, 11),
+            today=date(2026, 6, 1),
+        )
+
+        items, total = get_leave_requests(
+            self.db,
+            employee_id=self.bob.id,
+            leave_type=LeaveType.ANNUAL,
+            status=LeaveStatus.PENDING,
+            from_date=date(2026, 6, 1),
+            to_date=date(2026, 6, 30),
+            page=1,
+            page_size=10,
+        )
+
+        self.assertEqual(total, 1)
+        self.assertEqual([item.id for item in items], [annual_request.id])
 
     def test_get_leave_balances(self):
-        # TODO: implement
-        self.assertTrue(True)
+        balances = get_leave_balances(self.db, employee_id=self.bob.id, year=2026)
+
+        annual_balance = next(balance for balance in balances if balance.leave_type == LeaveType.ANNUAL)
+        self.assertEqual(annual_balance.total_units, 28)
+        self.assertEqual(annual_balance.used_units, 0)
+        self.assertEqual(annual_balance.total_days, 14.0)
+        self.assertEqual(annual_balance.used_days, 0.0)
+        self.assertEqual(annual_balance.remaining_days, 14.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 ## Summary

Implemented the leave management workflow for the FastAPI service layer, including leave request creation, approval/rejection, cancellation, listing, balance retrieval, and leave usage preview.

The implementation supports half-day leave through `am` / `pm`sessions, excludes weekends and Malaysia national public holidays from leave usage, prevents overlapping active leave requests, validates available balances, supports cross-year leave deduction, and exposes leave usage/balances in days while storing half-day units internally.

  ## Design Document

  See `DESIGN.md`.

  ## Implementation Notes

  - Leave duration is calculated with a shared `leave_calculator` module so preview, create, approval, cancellation, and overlap checks use the same rules.
  - The API exposes user-facing day values such as `leave_usage_days`, `total_days`, `used_days`, and `remaining_days`.
  - The database stores integer half-day units (`leave_usage_units`, `total_units`, `used_units`) to avoid floating-point balance errors.
  - `POST /leave-requests/preview` returns usage details without creating a request, checking balance, or mutating data.
  - Pending leave requests count against available leave during creation, but balances are deducted only on approval.
  - Approval is idempotent for the same final decision, so retrying an already approved/rejected review does not double deduct or mutate balance again.
  - Cancelling approved future leave restores the deducted balance; pending cancellation does not affect balance.
  - Approval authority is limited to the employee's direct manager based on `manager_id`.
  - Public holiday exclusion uses the `holidays` package with Malaysia national holidays.
  - The test suite covers service and API behavior, including validation, overlap, approval, cancellation, preview, cross-year deduction, and pagination/listing behavior.
  -  Added Pydantic models for request validation and API response serialization.
  - Domain persistence remains on SQLAlchemy models; Pydantic is used at the API boundary.

## Checklist

- [x] I have written and attached a DESIGN.md
- [x] I have implemented the required service functions in src/services.py
- [x] Tests pass (`python -m pytest tests/`)
- [x] Server starts and responds to requests (`uvicorn src.app:app --reload`)
- [x] I have considered edge cases (overlapping leave, insufficient balance, self-approval)

## About You

Tell us a bit about yourself:
- I have 5+ years of experience developing back-end and front end code.
- I am most familiar with Vue.js, Laravel and Flutter. In my current working place, I lead and took the responsibilities in migrating our complex and vast web apps from Vue.js 2 to Vue.js 3.
- I once work with python during my FYP project and internship years with iSaham.
- I am looking for a more work life balance and a new environment to explore and learn new things(I love exploring new things).

Please do reach me by email: abdulqayyumcheri@gmail.com or by contact number +60132470473.

Hoping to hear from you soon :) Thanks.
